### PR TITLE
Add geonode project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+downloaded
+geoserver
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# jetbrains project settings
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+FROM python:2.7.14-stretch
+MAINTAINER GeoNode development team
+
+RUN mkdir -p /usr/src/igb
+
+WORKDIR /usr/src/igb
+
+# This section is borrowed from the official Django image but adds GDAL and others
+RUN apt-get update && apt-get install -y \
+		gcc \
+		gettext \
+		postgresql-client libpq-dev \
+		sqlite3 \
+                python-gdal python-psycopg2 \
+                python-imaging python-lxml \
+                python-dev libgdal-dev \
+                python-ldap \
+                libmemcached-dev libsasl2-dev zlib1g-dev \
+                python-pylibmc \
+                uwsgi uwsgi-plugin-python \
+	--no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+
+COPY wait-for-databases.sh /usr/bin/wait-for-databases
+RUN chmod +x /usr/bin/wait-for-databases
+
+# Upgrade pip
+RUN pip install --upgrade pip
+
+# To understand the next section (the need for requirements.txt and setup.py)
+# Please read: https://packaging.python.org/requirements/
+
+# python-gdal does not seem to work, let's install manually the version that is
+# compatible with the provided libgdal-dev
+# superseded by pygdal
+#RUN pip install GDAL==2.1.3 --global-option=build_ext --global-option="-I/usr/include/gdal"
+RUN GDAL_VERSION=`gdal-config --version` \
+    && PYGDAL_VERSION="$(pip install pygdal==$GDAL_VERSION 2>&1 | grep -oP '(?<=: )(.*)(?=\))' | grep -oh $GDAL_VERSION\.[0-9])" \
+    && pip install pygdal==$PYGDAL_VERSION
+
+# fix for known bug in system-wide packages
+RUN ln -fs /usr/lib/python2.7/plat-x86_64-linux-gnu/_sysconfigdata*.py /usr/lib/python2.7/
+
+COPY . /usr/src/igb
+
+RUN chmod +x /usr/src/igb/tasks.py \
+    && chmod +x /usr/src/igb/entrypoint.sh
+
+# app-specific requirements
+RUN pip install --upgrade --no-cache-dir --src /usr/src -r requirements.txt
+RUN pip install --upgrade -e .
+
+ENTRYPOINT ["/usr/src/igb/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+up:
+	# bring up the services
+	docker-compose up -d
+
+build:
+	docker-compose build django
+	docker-compose build celery
+
+sync:
+	# set up the database tablea
+	docker-compose run django python manage.py makemigrations --noinput
+	docker-compose exec django python manage.py migrate account --noinput
+	docker-compose run django python manage.py migrate --noinput
+
+wait:
+	sleep 5
+
+logs:
+	docker-compose logs --follow
+
+down:
+	docker-compose down
+
+test:
+	docker-compose run django python manage.py test --failfast
+
+reset: down up wait sync
+
+hardreset: pull build reset

--- a/dev_config.yml
+++ b/dev_config.yml
@@ -1,0 +1,9 @@
+---
+GEOSERVER_URL: "https://build.geo-solutions.it/geonode/geoserver/latest/geoserver-2.14.x.war"
+DATA_DIR_URL: "https://build.geo-solutions.it/geonode/geoserver/latest/data-2.14.x.zip"
+JETTY_RUNNER_URL: "http://repo2.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.7.v20170914/jetty-runner-9.4.7.v20170914.jar"
+WINDOWS:
+  py2exe: "http://downloads.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.win32-py2.7.exe"
+  nose: "https://s3.amazonaws.com/geonodedeps/nose-1.3.3.win32-py2.7.exe"
+  pyproj: "https://pyproj.googlecode.com/files/pyproj-1.9.3.win32-py2.7.exe"
+  lxml: "https://pypi.python.org/packages/2.7/l/lxml/lxml-3.6.0.win32-py2.7.exe"

--- a/docker-compose.development.override.yml
+++ b/docker-compose.development.override.yml
@@ -1,0 +1,37 @@
+version: '2.2'
+services:
+  django:
+    command: python manage.py runserver --settings=igb.settings 0.0.0.0:8000
+    volumes:
+      - .:/usr/src/igb
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DOCKER_ENV: development
+      DEBUG: 'True'
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      SITEURL: http://localhost/
+      ALLOWED_HOSTS: "['localhost']"
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+
+  celery:
+    command: celery worker --app=igb.celeryapp:app --broker=amqp://guest:guest@rabbitmq:5672/ -B -l INFO
+    volumes:
+      - .:/usr/src/igb
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DOCKER_ENV: development
+      DEBUG: 'True'
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      SITEURL: http://localhost/
+      ALLOWED_HOSTS: "['localhost']"
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+
+  geoserver:
+    environment:
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      NGINX_BASE_URL:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,221 @@
+version: '2.2'
+services:
+
+  db:
+    image: geonode/postgis:10
+    restart: unless-stopped
+    container_name: db4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: db
+      org.geonode.instance.name: geonode
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+      - dbbackups:/pg_backups
+    environment:
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+
+  elasticsearch:
+    image: elasticsearch:2.4.1
+    restart: unless-stopped
+    container_name: elasticsearch4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    tty: true
+    labels:
+        org.geonode.component: elasticsearch
+        org.geonode.instance.name: geonode
+
+  rabbitmq:
+    image: rabbitmq
+    restart: unless-stopped
+    container_name: rabbitmq4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    tty: true
+    labels:
+        org.geonode.component: rabbitmq
+        org.geonode.instance.name: geonode
+
+  celery:
+    restart: unless-stopped
+    build: .
+    container_name: celery4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: celery
+        org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+    command: celery worker --app=igb.celeryapp:app -B -l INFO
+    volumes:
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DJANGO_SETTINGS_MODULE: igb.settings
+      GEONODE_INSTANCE_NAME: geonode
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      DEFAULT_BACKEND_DATASTORE: datastore
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      ASYNC_SIGNALS: 'True'
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      DOCKER_ENV: development
+      IS_CELERY: 'True'
+      C_FORCE_ROOT: 1
+      SITEURL: http://localhost/
+      # replaced with defaults in settings
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      OGC_REQUEST_TIMEOUT: 300
+      STATIC_ROOT: /mnt/volumes/statics/static/
+      MEDIA_ROOT: /mnt/volumes/statics/uploaded/
+      GEOIP_PATH: /mnt/volumes/statics/geoip.db
+      ALLOWED_HOSTS: "['*']"
+      ADMIN_EMAILS: ''
+      DEFAULT_BACKEND_UPLOADER: geonode.importer
+      TIME_ENABLED: 'True'
+      MOSAIC_ENABLED: 'False'
+      GEOGIG_ENABLED: 'False'
+      HAYSTACK_SEARCH: 'False'
+      HAYSTACK_ENGINE_URL: http://elasticsearch:9200/
+      HAYSTACK_ENGINE_INDEX_NAME: haystack
+      HAYSTACK_SEARCH_RESULTS_PER_PAGE: 200
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      # See https://github.com/geosolutions-it/geonode-generic/issues/28
+      # to see why we force API version to 1.24
+      DOCKER_API_VERSION: "1.24"
+
+  geoserver:
+    image: geonode/geoserver:2.14.x
+    restart: unless-stopped
+    container_name: geoserver4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: geoserver
+        org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+      - data-dir-conf
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      DOCKERHOST:
+      DOCKER_HOST_IP:
+      GEONODE_HOST_IP:
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      PUBLIC_PORT: 80
+      NGINX_BASE_URL:
+      GEOSERVER_JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxPermSize=512m -XX:PermSize=256m -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ParallelGCThreads=4 -Dfile.encoding=UTF8 -Duser.timezone=GMT -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT -Dorg.geotools.shapefile.datetime=true"
+
+  django:
+    restart: unless-stopped
+    build: .
+    container_name: django4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: django
+      org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+      - data-dir-conf
+    command: paver start_django -b 0.0.0.0:8000
+    volumes:
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DJANGO_SETTINGS_MODULE: igb.settings
+      GEONODE_INSTANCE_NAME: geonode
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      DEFAULT_BACKEND_DATASTORE: datastore
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      ASYNC_SIGNALS: 'True'
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      DOCKER_ENV: development
+      IS_CELERY: 'False'
+      C_FORCE_ROOT: 1
+      SITEURL: http://localhost/
+      # replaced with defaults in settings
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      OGC_REQUEST_TIMEOUT: 300
+      STATIC_ROOT: /mnt/volumes/statics/static/
+      MEDIA_ROOT: /mnt/volumes/statics/uploaded/
+      GEOIP_PATH: /mnt/volumes/statics/geoip.db
+      ALLOWED_HOSTS: "['*']"
+      ADMIN_EMAILS: ''
+      DEFAULT_BACKEND_UPLOADER: geonode.importer
+      TIME_ENABLED: 'True'
+      MOSAIC_ENABLED: 'False'
+      GEOGIG_ENABLED: 'False'
+      HAYSTACK_SEARCH: 'False'
+      HAYSTACK_ENGINE_URL: http://elasticsearch:9200/
+      HAYSTACK_ENGINE_INDEX_NAME: haystack
+      HAYSTACK_SEARCH_RESULTS_PER_PAGE: 200
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      # See https://github.com/geosolutions-it/geonode-generic/issues/28
+      # to see why we force API version to 1.24
+      DOCKER_API_VERSION: "1.24"
+
+  geonode:
+    image: geonode/nginx:development
+    restart: unless-stopped
+    container_name: nginx4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: nginx
+        org.geonode.instance.name: geonode
+    depends_on:
+      - django
+      - celery
+      - geoserver
+    ports:
+      - 80:80
+    volumes:
+      - statics:/mnt/volumes/statics
+
+
+  data-dir-conf:
+    image: geonode/geoserver_data:2.14.x
+    restart: on-failure
+    container_name: gsconf4${COMPOSE_PROJECT_NAME}
+    labels:
+        org.geonode.component: conf
+        org.geonode.instance.name: geonode
+    command: /bin/true
+    # command: tail -f /dev/null
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+
+
+volumes:
+  geoserver-data-dir:
+#    name: ${COMPOSE_PROJECT_NAME}-gsdatadir
+  dbdata:
+#    name: ${COMPOSE_PROJECT_NAME}-dbdata
+  dbbackups:
+#     driver: ${BACKUPS_VOLUME_DRIVER}
+#    name: ${COMPOSE_PROJECT_NAME}-dbbackups
+  statics:
+#    name: ${COMPOSE_PROJECT_NAME}-statics

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,25 @@
+version: '2.2'
+services:
+  django:
+    environment:
+      DEBUG: 'True'
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      SITEURL: http://localhost/
+      ALLOWED_HOSTS: "['localhost']"
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+
+  celery:
+    environment:
+      DEBUG: 'True'
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      SITEURL: http://localhost/
+      ALLOWED_HOSTS: "['localhost']"
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+
+  geoserver:
+    environment:
+      GEONODE_LB_HOST_IP: localhost
+      GEONODE_LB_PORT: 80
+      NGINX_BASE_URL:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,224 @@
+version: '2.2'
+services:
+
+  db:
+    image: geonode/postgis:10
+    restart: unless-stopped
+    container_name: db4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: db
+      org.geonode.instance.name: geonode
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+      - dbbackups:/pg_backups
+    environment:
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+
+  elasticsearch:
+    image: elasticsearch:2.4.1
+    restart: unless-stopped
+    container_name: elasticsearch4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    tty: true
+    labels:
+        org.geonode.component: elasticsearch
+        org.geonode.instance.name: geonode
+
+  rabbitmq:
+    image: rabbitmq
+    restart: unless-stopped
+    container_name: rabbitmq4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    tty: true
+    labels:
+        org.geonode.component: rabbitmq
+        org.geonode.instance.name: geonode
+
+  celery:
+    restart: unless-stopped
+    build: .
+    container_name: celery4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: celery
+        org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+    # command: celery worker --app=igb.celeryapp:app -B -l INFO
+    volumes:
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DJANGO_SETTINGS_MODULE: igb.settings
+      GEONODE_INSTANCE_NAME: geonode
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      DEFAULT_BACKEND_DATASTORE: datastore
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      ASYNC_SIGNALS: 'True'
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      CELERY_CMD: celery worker --app=igb.celeryapp:app --broker=amqp://guest:guest@rabbitmq:5672/ -B -l INFO
+      # CELERY_CMD: celery worker --app=igb.celeryapp:app --broker=memory:// -B -l INFO
+      DOCKER_ENV: production
+      IS_CELERY: 'True'
+      C_FORCE_ROOT: 1
+      SITEURL: http://localhost/
+      # replaced with defaults in settings
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      OGC_REQUEST_TIMEOUT: 300
+      STATIC_ROOT: /mnt/volumes/statics/static/
+      MEDIA_ROOT: /mnt/volumes/statics/uploaded/
+      GEOIP_PATH: /mnt/volumes/statics/geoip.db
+      ALLOWED_HOSTS: "['*']"
+      ADMIN_EMAILS: ''
+      DEFAULT_BACKEND_UPLOADER: geonode.importer
+      TIME_ENABLED: 'True'
+      MOSAIC_ENABLED: 'False'
+      GEOGIG_ENABLED: 'False'
+      HAYSTACK_SEARCH: 'False'
+      HAYSTACK_ENGINE_URL: http://elasticsearch:9200/
+      HAYSTACK_ENGINE_INDEX_NAME: haystack
+      HAYSTACK_SEARCH_RESULTS_PER_PAGE: 200
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      # See https://github.com/geosolutions-it/geonode-generic/issues/28
+      # to see why we force API version to 1.24
+      DOCKER_API_VERSION: "1.24"
+
+  geoserver:
+    image: geonode/geoserver:2.14.x
+    restart: unless-stopped
+    container_name: geoserver4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: geoserver
+        org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+      - data-dir-conf
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      DOCKERHOST:
+      DOCKER_HOST_IP:
+      GEONODE_HOST_IP:
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      PUBLIC_PORT: 80
+      NGINX_BASE_URL:
+      GEOSERVER_JAVA_OPTS: "-Djava.awt.headless=true -XX:MaxPermSize=512m -XX:PermSize=256m -Xms512m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:ParallelGCThreads=4 -Dfile.encoding=UTF8 -Duser.timezone=GMT -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT -Dorg.geotools.shapefile.datetime=true"
+
+  django:
+    restart: unless-stopped
+    build: .
+    container_name: django4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: django
+      org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - elasticsearch
+      - rabbitmq
+      - data-dir-conf
+    # command: paver start_django -b 0.0.0.0:8000
+    volumes:
+      - statics:/mnt/volumes/statics
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      DJANGO_SETTINGS_MODULE: igb.settings
+      GEONODE_INSTANCE_NAME: geonode
+      GEONODE_LB_HOST_IP:
+      GEONODE_LB_PORT:
+      DEFAULT_BACKEND_DATASTORE: datastore
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+      ASYNC_SIGNALS: 'True'
+      BROKER_URL: amqp://guest:guest@rabbitmq:5672
+      DOCKER_ENV: production
+      UWSGI_CMD: uwsgi --ini /usr/src/igb/uwsgi.ini
+      IS_CELERY: 'False'
+      C_FORCE_ROOT: 1
+      SITEURL: http://localhost/
+      # replaced with defaults in settings
+      GEOSERVER_PUBLIC_LOCATION: http://localhost/gs/
+      GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+      OGC_REQUEST_TIMEOUT: 300
+      STATIC_ROOT: /mnt/volumes/statics/static/
+      MEDIA_ROOT: /mnt/volumes/statics/uploaded/
+      GEOIP_PATH: /mnt/volumes/statics/geoip.db
+      ALLOWED_HOSTS: "['*']"
+      ADMIN_EMAILS: ''
+      DEFAULT_BACKEND_UPLOADER: geonode.importer
+      TIME_ENABLED: 'True'
+      MOSAIC_ENABLED: 'False'
+      GEOGIG_ENABLED: 'False'
+      HAYSTACK_SEARCH: 'False'
+      HAYSTACK_ENGINE_URL: http://elasticsearch:9200/
+      HAYSTACK_ENGINE_INDEX_NAME: haystack
+      HAYSTACK_SEARCH_RESULTS_PER_PAGE: 200
+      # GEOSERVER_ADMIN_PASSWORD: admin
+      # See https://github.com/geosolutions-it/geonode-generic/issues/28
+      # to see why we force API version to 1.24
+      DOCKER_API_VERSION: "1.24"
+
+  geonode:
+    image: geonode/nginx:geoserver
+    restart: unless-stopped
+    container_name: nginx4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: nginx
+        org.geonode.instance.name: geonode
+    depends_on:
+      - django
+      - celery
+      - geoserver
+    ports:
+      - 80:80
+    volumes:
+      - statics:/mnt/volumes/statics
+
+
+  data-dir-conf:
+    image: geonode/geoserver_data:2.14.x
+    restart: on-failure
+    container_name: gsconf4${COMPOSE_PROJECT_NAME}
+    labels:
+        org.geonode.component: conf
+        org.geonode.instance.name: geonode
+    command: /bin/true
+    # command: tail -f /dev/null
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+
+
+volumes:
+  geoserver-data-dir:
+#    name: ${COMPOSE_PROJECT_NAME}-gsdatadir
+  dbdata:
+#    name: ${COMPOSE_PROJECT_NAME}-dbdata
+  dbbackups:
+#     driver: ${BACKUPS_VOLUME_DRIVER}
+#    name: ${COMPOSE_PROJECT_NAME}-dbbackups
+  statics:
+#    name: ${COMPOSE_PROJECT_NAME}-statics

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+/usr/local/bin/invoke update
+
+source $HOME/.override_env
+
+echo DATABASE_URL=$DATABASE_URL
+echo GEODATABASE_URL=$GEODATABASE_URL
+echo SITEURL=$SITEURL
+echo ALLOWED_HOSTS=$ALLOWED_HOSTS
+echo GEOSERVER_PUBLIC_LOCATION=$GEOSERVER_PUBLIC_LOCATION
+
+/usr/local/bin/invoke waitfordbs
+echo "waitfordbs task done"
+
+echo "running migrations"
+/usr/local/bin/invoke migrations
+echo "migrations task done"
+
+if [ ! -e "/mnt/volumes/statics/geonode_init.lock" ]; then
+    /usr/local/bin/invoke prepare
+    echo "prepare task done"
+    /usr/local/bin/invoke fixtures
+    echo "fixture task done"
+fi
+/usr/local/bin/invoke initialized
+echo "initialized"
+
+echo "refresh static data"
+/usr/local/bin/invoke statics
+echo "static data refreshed"
+
+cmd="$@"
+
+echo DOCKER_ENV=$DOCKER_ENV
+
+if [ -z ${DOCKER_ENV} ] || [ ${DOCKER_ENV} = "development" ]
+then
+
+    echo "Executing standard Django server $cmd for Development"
+
+else
+
+    if [ ${IS_CELERY} = "true" ]  || [ ${IS_CELERY} = "True" ]
+    then
+
+        cmd=$CELERY_CMD
+        echo "Executing Celery server $cmd for Production"
+
+    else
+
+        cmd=$UWSGI_CMD
+        echo "Executing UWSGI server $cmd for Production"
+
+    fi
+
+fi
+echo 'got command ${cmd}'
+exec $cmd

--- a/fixtures/default_oauth_apps.json
+++ b/fixtures/default_oauth_apps.json
@@ -1,0 +1,21 @@
+[
+{
+    "model": "oauth2_provider.application",
+    "pk": 1001,
+    "fields": {
+        "skip_authorization": true,
+        "created": "2018-05-31T10:00:31.661Z",
+        "updated": "2018-05-31T11:30:31.245Z",
+        "algorithm": "RS256",
+        "redirect_uris": "http://localhost:8080/geoserver/index.html\nhttp://localhost/geoserver/index.html",
+        "name": "GeoServer",
+        "authorization_grant_type": "authorization-code",
+        "client_type": "confidential",
+        "client_id": "Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV",
+        "client_secret": "rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3",
+        "user": [
+            "admin"
+        ]
+    }
+}
+]

--- a/fixtures/default_oauth_apps_docker.json
+++ b/fixtures/default_oauth_apps_docker.json
@@ -1,0 +1,21 @@
+[
+{
+    "model": "oauth2_provider.application",
+    "pk": 1001,
+    "fields": {
+        "skip_authorization": true,
+        "created": "2018-05-31T10:00:31.661Z",
+        "updated": "2018-05-31T11:30:31.245Z",
+        "algorithm": "RS256",
+        "redirect_uris": "http://geonode/geoserver",
+        "name": "GeoServer",
+        "authorization_grant_type": "authorization-code",
+        "client_type": "confidential",
+        "client_id": "Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV",
+        "client_secret": "rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDBY9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3",
+        "user": [
+            "admin"
+        ]
+    }
+}
+]

--- a/fixtures/initial_data.json
+++ b/fixtures/initial_data.json
@@ -1,0 +1,4849 @@
+[
+    {
+        "pk": 1,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "information pertaining to earth sciences. Examples: geophysical features and processes, geology, minerals, sciences dealing with the composition, structure and origin of the earth s rocks, risks of earthquakes, volcanic activity, landslides, gravity information, soils, permafrost, hydrogeology, erosion",
+            "gn_description": "Geoscientific Information",
+            "is_choice": true,
+            "fa_class": "fa-bullseye",
+            "identifier": "geoscientificInformation"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "rearing of animals and/or cultivation of plants. Examples: agriculture, irrigation, aquaculture, plantations, herding, pests and diseases affecting crops and livestock",
+            "gn_description": "Farming",
+            "is_choice": true,
+            "fa_class": "fa-lemon-o",
+            "identifier": "farming"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "height above or below sea level. Examples: altitude, bathymetry, digital elevation models, slope, derived products",
+            "gn_description": "Elevation",
+            "is_choice": true,
+            "fa_class": "fa-flag",
+            "identifier": "elevation"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "energy, water and waste systems and communications infrastructure and services. Examples: hydroelectricity, geothermal, solar and nuclear sources of energy, water purification and distribution, sewage collection and disposal, electricity and gas distribution, data communication, telecommunication, radio, communication networks",
+            "gn_description": "Utilities Communication",
+            "is_choice": true,
+            "fa_class": "fa-phone",
+            "identifier": "utilitiesCommunication"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "features and characteristics of salt water bodies (excluding inland waters). Examples: tides, tidal waves, coastal information, reefs",
+            "gn_description": "Oceans",
+            "is_choice": true,
+            "fa_class": "fa-anchor",
+            "identifier": "oceans"
+        }
+    },
+    {
+        "pk": 6,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "legal land descriptions. Examples: political and administrative boundaries",
+            "gn_description": "Boundaries",
+            "is_choice": true,
+            "fa_class": "fa-ellipsis-h",
+            "identifier": "boundaries"
+        }
+    },
+    {
+        "pk": 7,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "inland water features, drainage systems and their characteristics. Examples: rivers and glaciers, salt lakes, water utilization plans, dams, currents, floods, water quality, hydrographic charts",
+            "gn_description": "Inland Waters",
+            "is_choice": true,
+            "fa_class": "fa-tint",
+            "identifier": "inlandWaters"
+        }
+    },
+    {
+        "pk": 8,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "military bases, structures, activities. Examples: barracks, training grounds, military transportation, information collection",
+            "gn_description": "Intelligence Military",
+            "is_choice": true,
+            "fa_class": "fa-fighter-jet",
+            "identifier": "intelligenceMilitary"
+        }
+    },
+    {
+        "pk": 9,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "environmental resources, protection and conservation. Examples: environmental pollution, waste storage and treatment, environmental impact assessment, monitoring environmental risk, nature reserves, landscape",
+            "gn_description": "Environment",
+            "is_choice": true,
+            "fa_class": "fa-tree",
+            "identifier": "environment"
+        }
+    },
+    {
+        "pk": 10,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "positional information and services. Examples: addresses, geodetic networks, control points, postal zones and services, place names",
+            "gn_description": "Location",
+            "is_choice": true,
+            "fa_class": "fa-map-marker",
+            "identifier": "location"
+        }
+    },
+    {
+        "pk": 11,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "economic activities, conditions and employment. Examples: production, labour, revenue, commerce, industry, tourism and ecotourism, forestry, fisheries, commercial or subsistence hunting, exploration and exploitation of resources such as minerals, oil and gas",
+            "gn_description": "Economy",
+            "is_choice": true,
+            "fa_class": "fa-shopping-cart",
+            "identifier": "economy"
+        }
+    },
+    {
+        "pk": 12,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "information used for appropriate actions for future use of the land. Examples: land use maps, zoning maps, cadastral surveys, land ownership",
+            "gn_description": "Planning Cadastre",
+            "is_choice": true,
+            "fa_class": "fa-home",
+            "identifier": "planningCadastre"
+        }
+    },
+    {
+        "pk": 13,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "flora and/or fauna in natural environment. Examples: wildlife, vegetation, biological sciences, ecology, wilderness, sealife, wetlands, habitat",
+            "gn_description": "Biota",
+            "is_choice": true,
+            "fa_class": "fa-leaf",
+            "identifier": "biota"
+        }
+    },
+    {
+        "pk": 14,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "health, health services, human ecology, and safety. Examples: disease and illness, factors affecting health, hygiene, substance abuse, mental and physical health, health services",
+            "gn_description": "Health",
+            "is_choice": true,
+            "fa_class": "fa-stethoscope",
+            "identifier": "health"
+        }
+    },
+    {
+        "pk": 15,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "base maps. Examples: land cover, topographic maps, imagery, unclassified images, annotations",
+            "gn_description": "Imagery Base Maps Earth Cover",
+            "is_choice": true,
+            "fa_class": "fa-globe",
+            "identifier": "imageryBaseMapsEarthCover"
+        }
+    },
+    {
+        "pk": 16,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "means and aids for conveying persons and/or goods. Examples: roads, airports/airstrips, shipping routes, tunnels, nautical charts, vehicle or vessel location, aeronautical charts, railways",
+            "gn_description": "Transportation",
+            "is_choice": true,
+            "fa_class": "fa-truck",
+            "identifier": "transportation"
+        }
+    },
+    {
+        "pk": 17,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "characteristics of society and cultures. Examples: settlements, anthropology, archaeology, education, traditional beliefs, manners and customs, demographic data, recreational areas and activities, social impact assessments, crime and justice, census information",
+            "gn_description": "Society",
+            "is_choice": true,
+            "fa_class": "fa-comments",
+            "identifier": "society"
+        }
+    },
+    {
+        "pk": 18,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "man-made construction. Examples: buildings, museums, churches, factories, housing, monuments, shops, towers",
+            "gn_description": "Structure",
+            "is_choice": true,
+            "fa_class": "fa-building",
+            "identifier": "structure"
+        }
+    },
+    {
+        "pk": 19,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "processes and phenomena of the atmosphere. Examples: cloud cover, weather, climate, atmospheric conditions, climate change, precipitation",
+            "gn_description": "Climatology Meteorology Atmosphere",
+            "is_choice": true,
+            "fa_class": "fa-cloud",
+            "identifier": "climatologyMeteorologyAtmosphere"
+        }
+    },
+    {
+        "pk": 20,
+        "model": "base.topiccategory",
+        "fields": {
+            "description": "settlements, anthropology, archaeology, education, traditional beliefs, manners and customs, demographic data, recreational areas and activities, social impact assessments, crime and justice, census information. Economic activities, conditions and employment",
+            "gn_description": "Population",
+            "is_choice": true,
+            "fa_class": "fa-male",
+            "identifier": "population"
+        }
+    },
+    {
+        "pk": 1,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "vector data is used to represent geographic data",
+            "identifier": "vector",
+            "description": "vector data is used to represent geographic data"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "grid data is used to represent geographic data",
+            "identifier": "grid",
+            "description": "grid data is used to represent geographic data"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "textual or tabular data is used to represent geographic data",
+            "identifier": "textTable",
+            "description": "textual or tabular data is used to represent geographic data"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "triangulated irregular network",
+            "identifier": "tin",
+            "description": "triangulated irregular network"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "three-dimensional view formed by the intersecting homologous rays of an overlapping pair of images",
+            "identifier": "stereoModel",
+            "description": "three-dimensional view formed by the intersecting homologous rays of an overlapping pair of images"
+        }
+    },
+    {
+        "pk": 6,
+        "model": "base.spatialrepresentationtype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "scene from a video recording",
+            "identifier": "video",
+            "description": "scene from a video recording"
+        }
+    },
+    {
+        "pk": 1,
+        "model": "base.license",
+        "fields": {
+            "identifier": "not_specified",
+            "name":"Not Specified",
+            "abbreviation":"",
+            "description":"The original author did not specify a license.",
+            "url":"",
+            "license_text":"Not applicable"
+        }
+    },
+{
+        "pk": 2,
+        "model": "base.license",
+        "fields": {
+            "identifier":"varied_original",
+            "name":"Varied / Original",
+            "abbreviation":"",
+            "description":"This item is either licensed under multiple licenses.  See the item's abstract for more information or contact the distributor.",
+            "url":"",
+            "license_text":"Not applicable"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "base.license",
+        "fields": {
+            "identifier":"varied_derived",
+            "name":"Varied / Derived",
+            "abbreviation":"",
+            "description":"The constituent parts of this item have different licenses.  Go to each part to see license information.",
+            "url":"",
+            "license_text":"Not applicable"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "base.license",
+        "fields": {
+            "identifier":"public_domain",
+            "name":"Public Domain",
+            "abbreviation":"PD",
+            "description":"Works in the public domain may be used freely without the permission of the former copyright owner.",
+            "url":"http://www.copyright.gov/help/faq/faq-definitions.html",
+            "license_text":"The public domain is not a place. A work of authorship is in the “public domain” if it is no longer under copyright protection or if it failed to meet the requirements for copyright protection. Works in the public domain may be used freely without the permission of the former copyright owner."
+        }
+    },
+    {
+        "pk": 5,
+        "model": "base.license",
+        "fields": {
+            "identifier":"public_domain_usg",
+            "name":"Public Domain / USG",
+            "abbreviation":"PD/USG",
+            "description":"This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105.",
+            "url":"https://raw.githubusercontent.com/state-hiu/cybergis-licenses/master/licenses/PUBLICDOMAIN-LICENSE-RAW.txt",
+            "license_text":"This project constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105."
+        }
+    },
+    {
+        "pk": 6,
+        "model": "base.license",
+        "fields": {
+            "identifier":"odbl",
+            "name":"Open Data Commons Open Database License / OSM",
+            "abbreviation":"ODbL/OSM",
+            "description":"You are free to copy, distribute, transmit and adapt our data, as long as you credit OpenStreetMap and its contributors\nIf you alter or build upon our data, you may distribute the result only under the same licence.",
+            "url":"http://www.openstreetmap.org/copyright",
+            "license_text":""
+        }
+    },
+    {
+        "pk": 7,
+        "model": "base.license",
+        "fields": {
+            "identifier":"nextview",
+            "name":"NextView",
+            "abbreviation":"NV",
+            "description":"This data is licensed for use by the US Government (USG) under the NextView (NV) license and copyrighted by Digital Globe or GeoEye. The NV license allows the USG to share the imagery and Literal Imagery Derived Products (LIDP) with entities outside the USG when that entity is working directly with the USG, for the USG, or in a manner that is directly beneficial to the USG. The party receiving the data can only use the imagery or LIDP for the original purpose or only as otherwise agreed to by the USG. The party receiving the data cannot share the imagery or LIDP with a third party without express permission from the USG. At no time should this imagery or LIDP be used for other than USG-related purposes and must not be used for commercial gain. The copyright information should be maintained at all times. Your acceptance of these license terms is implied by your use.\nIn other words, you may only use NextView imagery linked from this site for digitizing OpenStreetMap data for humanitarian purposes.",
+            "url":"https://raw.githubusercontent.com/state-hiu/cybergis-licenses/master/licenses/NEXTVIEW-LICENSE-RAW.txt",
+            "license_text":""
+        }
+    },
+     {
+        "pk": 1,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "exclusive right to the publication, production, or sale of the rights to a literary, dramatic, musical, or artistic work, or to the use of a commercial print or label, granted by law for a specified period of time to an author, composer, artist, distributor",
+            "identifier": "copyright",
+            "description": "exclusive right to the publication, production, or sale of the rights to a literary, dramatic, musical, or artistic work, or to the use of a commercial print or label, granted by law for a specified period of time to an author, composer, artist, distributor"
+        }
+    },
+    {
+        "pk": 6,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "rights to financial benefit from and control of distribution of non-tangible property that is a result of creativity",
+            "identifier": "intellectualPropertyRights",
+            "description": "rights to financial benefit from and control of distribution of non-tangible property that is a result of creativity"
+        }
+    },
+    {
+        "pk": 5,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "formal permission to do something",
+            "identifier": "license",
+            "description": "formal permission to do something"
+        }
+    },
+    {
+        "pk": 8,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "otherRestrictions",
+            "identifier": "limitation not listed",
+            "description": "otherRestrictions"
+        }
+    },
+    {
+        "pk": 2,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "government has granted exclusive right to make, sell, use or license an invention or discovery",
+            "identifier": "patent",
+            "description": "government has granted exclusive right to make, sell, use or license an invention or discovery"
+        }
+    },
+    {
+        "pk": 3,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "produced or sold information awaiting a patent",
+            "identifier": "patentPending",
+            "description": "produced or sold information awaiting a patent"
+        }
+    },
+    {
+        "pk": 7,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "withheld from general circulation or disclosure",
+            "identifier": "restricted",
+            "description": "withheld from general circulation or disclosure"
+        }
+    },
+    {
+        "pk": 4,
+        "model": "base.restrictioncodetype",
+        "fields": {
+            "is_choice": true,
+            "gn_description": "a name, symbol, or other device identifying a product, officially registered and legally restricted to the use of the owner or manufacturer",
+            "identifier": "trademark",
+            "description": "a name, symbol, or other device identifying a product, officially registered and legally restricted to the use of the owner or manufacturer"
+        }
+    },
+    {
+      "pk": 1,
+      "model": "base.region",
+      "fields": {
+        "rght": 516,
+        "code": "GLO",
+        "name": "Global",
+        "parent": null,
+        "level": 0,
+        "lft": 1,
+        "tree_id": 90,
+        "bbox_x0": -180,
+        "bbox_x1": 180,
+        "bbox_y0": -90,
+        "bbox_y1": 90
+      }
+    },
+    {
+      "pk": 2,
+      "model": "base.region",
+      "fields": {
+        "rght": 212,
+        "code": "NAM",
+        "name": "North America",
+        "parent": 254,
+        "level": 2,
+        "lft": 203,
+        "tree_id": 90,
+        "bbox_x0": -167.276413,
+        "bbox_x1": -52.23304,
+        "bbox_y0": 5.49955,
+        "bbox_y1": 83.162102
+      }
+    },
+    {
+      "pk": 3,
+      "model": "base.region",
+      "fields": {
+        "rght": 202,
+        "code": "CAM",
+        "name": "Central America",
+        "parent": 254,
+        "level": 2,
+        "lft": 187,
+        "tree_id": 90,
+        "bbox_x0": -118.867172,
+        "bbox_x1": -66.869827,
+        "bbox_y0": -4.23048,
+        "bbox_y1": 32.71862
+      }
+    },
+    {
+      "pk": 4,
+      "model": "base.region",
+      "fields": {
+        "rght": 242,
+        "code": "SAM",
+        "name": "South America",
+        "parent": 254,
+        "level": 2,
+        "lft": 213,
+        "tree_id": 90,
+        "bbox_x0": -109.47493,
+        "bbox_x1": -26.33247,
+        "bbox_y0": -59.450451,
+        "bbox_y1": 13.39029
+      }
+    },
+    {
+      "pk": 5,
+      "model": "base.region",
+      "fields": {
+        "rght": 433,
+        "code": "EUR",
+        "name": "Europe",
+        "parent": null,
+        "level": 1,
+        "lft": 318,
+        "tree_id": 90,
+        "bbox_x0": -31.266001,
+        "bbox_x1": 39.869301,
+        "bbox_y0": 27.636311,
+        "bbox_y1": 81.008797
+      }
+    },
+    {
+      "pk": 6,
+      "model": "base.region",
+      "fields": {
+        "rght": 317,
+        "code": "ASI",
+        "name": "Asia",
+        "parent": null,
+        "level": 1,
+        "lft": 246,
+        "tree_id": 90,
+        "bbox_x0": 19.6381,
+        "bbox_x1": 180,
+        "bbox_y0": -12.56111,
+        "bbox_y1": 82.50045
+      }
+    },
+    {
+      "pk": 7,
+      "model": "base.region",
+      "fields": {
+        "rght": 316,
+        "code": "SEA",
+        "name": "Southeast Asia",
+        "parent": 6,
+        "level": 2,
+        "lft": 293,
+        "tree_id": 90,
+        "bbox_x0": 68.0327,
+        "bbox_x1": 141.021805,
+        "bbox_y0": -12.56111,
+        "bbox_y1": 35.504211
+      }
+    },
+    {
+      "pk": 8,
+      "model": "base.region",
+      "fields": {
+        "rght": 260,
+        "code": "CTA",
+        "name": "Central Asia",
+        "parent": 6,
+        "level": 2,
+        "lft": 247,
+        "tree_id": 90,
+        "bbox_x0": 44.236641,
+        "bbox_x1": 90.076767,
+        "bbox_y0": 33.890511,
+        "bbox_y1": 54.845139
+      }
+    },
+    {
+      "pk": 9,
+      "model": "base.region",
+      "fields": {
+        "rght": 292,
+        "code": "SAS",
+        "name": "South Asia",
+        "parent": 6,
+        "level": 2,
+        "lft": 277,
+        "tree_id": 90,
+        "bbox_x0": 19.6381,
+        "bbox_x1": 180,
+        "bbox_y0": -12.56111,
+        "bbox_y1": 82.50045
+      }
+    },
+    {
+      "pk": 10,
+      "model": "base.region",
+      "fields": {
+        "rght": 127,
+        "code": "AFR",
+        "name": "Africa",
+        "parent": null,
+        "level": 1,
+        "lft": 2,
+        "tree_id": 90,
+        "bbox_x0": -25.35874,
+        "bbox_x1": 63.525379,
+        "bbox_y0": -46.900452,
+        "bbox_y1": 37.56712
+      }
+    },
+    {
+      "pk": 11,
+      "model": "base.region",
+      "fields": {
+        "rght": 64,
+        "code": "NAF",
+        "name": "North Africa",
+        "parent": 10,
+        "level": 2,
+        "lft": 49,
+        "tree_id": 90,
+        "bbox_x0": -17.10317,
+        "bbox_x1": 38.833801,
+        "bbox_y0": 3.48639,
+        "bbox_y1": 37.56712
+      }
+    },
+    {
+      "pk": 12,
+      "model": "base.region",
+      "fields": {
+        "rght": 48,
+        "code": "EAF",
+        "name": "East Africa",
+        "parent": 10,
+        "level": 2,
+        "lft": 13,
+        "tree_id": 90,
+        "bbox_x0": 22.855089,
+        "bbox_x1": 63.94656,
+        "bbox_y0": -25.84763,
+        "bbox_y1": 17.467039
+      }
+    },
+    {
+      "pk": 13,
+      "model": "base.region",
+      "fields": {
+        "rght": 126,
+        "code": "WAF",
+        "name": "West Africa",
+        "parent": 10,
+        "level": 2,
+        "lft": 83,
+        "tree_id": 90,
+        "bbox_x0": -26.758421,
+        "bbox_x1": 24.002661,
+        "bbox_y0": -9.29925,
+        "bbox_y1": 27.702801
+      }
+    },
+    {
+      "pk": 14,
+      "model": "base.region",
+      "fields": {
+        "rght": 82,
+        "code": "SAF",
+        "name": "Southern Africa",
+        "parent": 10,
+        "level": 2,
+        "lft": 65,
+        "tree_id": 90,
+        "bbox_x0": 8.93107,
+        "bbox_x1": 42.74847,
+        "bbox_y0": -35.507481,
+        "bbox_y1": -13.27553
+      }
+    },
+    {
+      "pk": 15,
+      "model": "base.region",
+      "fields": {
+        "rght": 463,
+        "code": "MES",
+        "name": "Middle East",
+        "parent": null,
+        "level": 1,
+        "lft": 434,
+        "tree_id": 90,
+        "bbox_x0": 24.698099,
+        "bbox_x1": 63.317459,
+        "bbox_y0": 12.111,
+        "bbox_y1": 42.10751
+      }
+    },
+    {
+      "pk": 16,
+      "model": "base.region",
+      "fields": {
+        "rght": 245,
+        "code": "ANT",
+        "name": "Antarctica",
+        "parent": null,
+        "level": 1,
+        "lft": 244,
+        "tree_id": 90,
+        "bbox_x0": -180,
+        "bbox_x1": 180,
+        "bbox_y0": -90,
+        "bbox_y1": -73
+      }
+    },
+    {
+      "pk": 17,
+      "model": "base.region",
+      "fields": {
+        "rght": 249,
+        "code": "AFG",
+        "name": "Afghanistan",
+        "parent": 8,
+        "level": 3,
+        "lft": 248,
+        "tree_id": 90,
+        "bbox_x0": 60.478439,
+        "bbox_x1": 74.879433,
+        "bbox_y0": 29.37747,
+        "bbox_y1": 38.483421
+      }
+    },
+    {
+      "pk": 18,
+      "model": "base.region",
+      "fields": {
+        "rght": 320,
+        "code": "ALA",
+        "name": "Aland Islands",
+        "parent": 5,
+        "level": 2,
+        "lft": 319,
+        "tree_id": 90,
+        "bbox_x0": 19.262711,
+        "bbox_x1": 21.324409,
+        "bbox_y0": 59.736301,
+        "bbox_y1": 60.665581
+      }
+    },
+    {
+      "pk": 19,
+      "model": "base.region",
+      "fields": {
+        "rght": 322,
+        "code": "ALB",
+        "name": "Albania",
+        "parent": 5,
+        "level": 2,
+        "lft": 321,
+        "tree_id": 90,
+        "bbox_x0": 19.28219,
+        "bbox_x1": 21.057819,
+        "bbox_y0": 39.644489,
+        "bbox_y1": 42.660801
+      }
+    },
+    {
+      "pk": 20,
+      "model": "base.region",
+      "fields": {
+        "rght": 51,
+        "code": "DZA",
+        "name": "Algeria",
+        "parent": 11,
+        "level": 3,
+        "lft": 50,
+        "tree_id": 90,
+        "bbox_x0": -8.67386,
+        "bbox_x1": 11.97955,
+        "bbox_y0": 18.96002,
+        "bbox_y1": 37.093731
+      }
+    },
+    {
+      "pk": 21,
+      "model": "base.region",
+      "fields": {
+        "rght": 466,
+        "code": "ASM",
+        "name": "American Samoa",
+        "parent": 256,
+        "level": 2,
+        "lft": 465,
+        "tree_id": 90,
+        "bbox_x0": -171.091873,
+        "bbox_x1": -169.416077,
+        "bbox_y0": -14.38247,
+        "bbox_y1": -11.04969
+      }
+    },
+    {
+      "pk": 22,
+      "model": "base.region",
+      "fields": {
+        "rght": 324,
+        "code": "AND",
+        "name": "Andorra",
+        "parent": 5,
+        "level": 2,
+        "lft": 323,
+        "tree_id": 90,
+        "bbox_x0": 1.41382,
+        "bbox_x1": 1.78659,
+        "bbox_y0": 42.42873,
+        "bbox_y1": 42.65601
+      }
+    },
+    {
+      "pk": 23,
+      "model": "base.region",
+      "fields": {
+        "rght": 85,
+        "code": "AGO",
+        "name": "Angola",
+        "parent": 13,
+        "level": 3,
+        "lft": 84,
+        "tree_id": 90,
+        "bbox_x0": 11.6792,
+        "bbox_x1": 24.082109,
+        "bbox_y0": -18.04207,
+        "bbox_y1": -4.37259
+      }
+    },
+    {
+      "pk": 24,
+      "model": "base.region",
+      "fields": {
+        "rght": 131,
+        "code": "AIA",
+        "name": "Anguilla",
+        "parent": 255,
+        "level": 3,
+        "lft": 130,
+        "tree_id": 90,
+        "bbox_x0": -63.434872,
+        "bbox_x1": -62.916199,
+        "bbox_y0": 18.149549,
+        "bbox_y1": 18.61278
+      }
+    },
+    {
+      "pk": 25,
+      "model": "base.region",
+      "fields": {
+        "rght": 133,
+        "code": "ATG",
+        "name": "Antigua and Barbuda",
+        "parent": 255,
+        "level": 3,
+        "lft": 132,
+        "tree_id": 90,
+        "bbox_x0": -62.352402,
+        "bbox_x1": -61.659081,
+        "bbox_y0": 16.927219,
+        "bbox_y1": 17.72938
+      }
+    },
+    {
+      "pk": 26,
+      "model": "base.region",
+      "fields": {
+        "rght": 215,
+        "code": "ARG",
+        "name": "Argentina",
+        "parent": 4,
+        "level": 3,
+        "lft": 214,
+        "tree_id": 90,
+        "bbox_x0": -73.577782,
+        "bbox_x1": -53.637539,
+        "bbox_y0": -55.057362,
+        "bbox_y1": -21.78126
+      }
+    },
+    {
+      "pk": 27,
+      "model": "base.region",
+      "fields": {
+        "rght": 326,
+        "code": "ARM",
+        "name": "Armenia",
+        "parent": 5,
+        "level": 2,
+        "lft": 325,
+        "tree_id": 90,
+        "bbox_x0": 43.449749,
+        "bbox_x1": 46.630039,
+        "bbox_y0": 38.830521,
+        "bbox_y1": 41.30183
+      }
+    },
+    {
+      "pk": 28,
+      "model": "base.region",
+      "fields": {
+        "rght": 135,
+        "code": "ABW",
+        "name": "Aruba",
+        "parent": 255,
+        "level": 3,
+        "lft": 134,
+        "tree_id": 90,
+        "bbox_x0": -70.0611,
+        "bbox_x1": -69.8669,
+        "bbox_y0": 12.4061,
+        "bbox_y1": 12.6306
+      }
+    },
+    {
+      "pk": 29,
+      "model": "base.region",
+      "fields": {
+        "rght": 468,
+        "code": "AUS",
+        "name": "Australia",
+        "parent": 256,
+        "level": 2,
+        "lft": 467,
+        "tree_id": 90,
+        "bbox_x0": 112.921112,
+        "bbox_x1": 159.278717,
+        "bbox_y0": -54.640301,
+        "bbox_y1": -9.22882
+      }
+    },
+    {
+      "pk": 30,
+      "model": "base.region",
+      "fields": {
+        "rght": 328,
+        "code": "AUT",
+        "name": "Austria",
+        "parent": 5,
+        "level": 2,
+        "lft": 327,
+        "tree_id": 90,
+        "bbox_x0": 9.53079,
+        "bbox_x1": 17.160749,
+        "bbox_y0": 46.372299,
+        "bbox_y1": 49.02071
+      }
+    },
+    {
+      "pk": 31,
+      "model": "base.region",
+      "fields": {
+        "rght": 330,
+        "code": "AZE",
+        "name": "Azerbaijan",
+        "parent": 5,
+        "level": 2,
+        "lft": 329,
+        "tree_id": 90,
+        "bbox_x0": 44.7719,
+        "bbox_x1": 50.6078,
+        "bbox_y0": 38.3970,
+        "bbox_y1": 41.9056
+      }
+    },
+    {
+      "pk": 32,
+      "model": "base.region",
+      "fields": {
+        "rght": 137,
+        "code": "BHS",
+        "name": "Bahamas",
+        "parent": 255,
+        "level": 3,
+        "lft": 136,
+        "tree_id": 90,
+        "bbox_x0": -80.499229,
+        "bbox_x1": -72.649513,
+        "bbox_y0": 20.916059,
+        "bbox_y1": 27.933781
+      }
+    },
+    {
+      "pk": 33,
+      "model": "base.region",
+      "fields": {
+        "rght": 436,
+        "code": "BHR",
+        "name": "Bahrain",
+        "parent": 15,
+        "level": 2,
+        "lft": 435,
+        "tree_id": 90,
+        "bbox_x0": 50.385799,
+        "bbox_x1": 50.828499,
+        "bbox_y0": 25.5422,
+        "bbox_y1": 26.292391
+      }
+    },
+    {
+      "pk": 34,
+      "model": "base.region",
+      "fields": {
+        "rght": 279,
+        "code": "BGD",
+        "name": "Bangladesh",
+        "parent": 9,
+        "level": 3,
+        "lft": 278,
+        "tree_id": 90,
+        "bbox_x0": 88.028198,
+        "bbox_x1": 92.673599,
+        "bbox_y0": 20.585199,
+        "bbox_y1": 26.631701
+      }
+    },
+    {
+      "pk": 35,
+      "model": "base.region",
+      "fields": {
+        "rght": 139,
+        "code": "BRB",
+        "name": "Barbados",
+        "parent": 255,
+        "level": 3,
+        "lft": 138,
+        "tree_id": 90,
+        "bbox_x0": -59.648918,
+        "bbox_x1": -59.420368,
+        "bbox_y0": 13.03984,
+        "bbox_y1": 13.32725
+      }
+    },
+    {
+      "pk": 36,
+      "model": "base.region",
+      "fields": {
+        "rght": 332,
+        "code": "BLR",
+        "name": "Belarus",
+        "parent": 5,
+        "level": 2,
+        "lft": 331,
+        "tree_id": 90,
+        "bbox_x0": 23.17679,
+        "bbox_x1": 32.77071,
+        "bbox_y0": 51.256401,
+        "bbox_y1": 56.16571
+      }
+    },
+    {
+      "pk": 37,
+      "model": "base.region",
+      "fields": {
+        "rght": 334,
+        "code": "BEL",
+        "name": "Belgium",
+        "parent": 5,
+        "level": 2,
+        "lft": 333,
+        "tree_id": 90,
+        "bbox_x0": 2.54563,
+        "bbox_x1": 6.40791,
+        "bbox_y0": 49.496899,
+        "bbox_y1": 51.505081
+      }
+    },
+    {
+      "pk": 38,
+      "model": "base.region",
+      "fields": {
+        "rght": 189,
+        "code": "BLZ",
+        "name": "Belize",
+        "parent": 3,
+        "level": 3,
+        "lft": 188,
+        "tree_id": 90,
+        "bbox_x0": -89.224823,
+        "bbox_x1": -87.468132,
+        "bbox_y0": 15.8893,
+        "bbox_y1": 18.49655
+      }
+    },
+    {
+      "pk": 39,
+      "model": "base.region",
+      "fields": {
+        "rght": 87,
+        "code": "BEN",
+        "name": "Benin",
+        "parent": 13,
+        "level": 3,
+        "lft": 86,
+        "tree_id": 90,
+        "bbox_x0": 0.77456,
+        "bbox_x1": 3.8517,
+        "bbox_y0": 6.22574,
+        "bbox_y1": 12.41834
+      }
+    },
+    {
+      "pk": 40,
+      "model": "base.region",
+      "fields": {
+        "rght": 141,
+        "code": "BMU",
+        "name": "Bermuda",
+        "parent": 255,
+        "level": 3,
+        "lft": 140,
+        "tree_id": 90,
+        "bbox_x0": -64.896042,
+        "bbox_x1": -64.642952,
+        "bbox_y0": 32.230709,
+        "bbox_y1": 32.393829
+      }
+    },
+    {
+      "pk": 41,
+      "model": "base.region",
+      "fields": {
+        "rght": 281,
+        "code": "BTN",
+        "name": "Bhutan",
+        "parent": 9,
+        "level": 3,
+        "lft": 280,
+        "tree_id": 90,
+        "bbox_x0": 88.759521,
+        "bbox_x1": 92.125023,
+        "bbox_y0": 26.7075,
+        "bbox_y1": 28.3235
+      }
+    },
+    {
+      "pk": 42,
+      "model": "base.region",
+      "fields": {
+        "rght": 217,
+        "code": "BOL",
+        "name": "Bolivia",
+        "parent": 4,
+        "level": 3,
+        "lft": 216,
+        "tree_id": 90,
+        "bbox_x0": -69.640762,
+        "bbox_x1": -57.458092,
+        "bbox_y0": -22.89613,
+        "bbox_y1": -9.68056
+      }
+    },
+    {
+      "pk": 43,
+      "model": "base.region",
+      "fields": {
+        "rght": 336,
+        "code": "BIH",
+        "name": "Bosnia and Herzegovina",
+        "parent": 5,
+        "level": 2,
+        "lft": 335,
+        "tree_id": 90,
+        "bbox_x0": 15.74909,
+        "bbox_x1": 19.62907,
+        "bbox_y0": 42.56451,
+        "bbox_y1": 45.276001
+      }
+    },
+    {
+      "pk": 44,
+      "model": "base.region",
+      "fields": {
+        "rght": 67,
+        "code": "BWA",
+        "name": "Botswana",
+        "parent": 14,
+        "level": 3,
+        "lft": 66,
+        "tree_id": 90,
+        "bbox_x0": 19.999531,
+        "bbox_x1": 29.360781,
+        "bbox_y0": -26.90724,
+        "bbox_y1": -17.780809
+      }
+    },
+    {
+      "pk": 45,
+      "model": "base.region",
+      "fields": {
+        "rght": 219,
+        "code": "BRA",
+        "name": "Brazil",
+        "parent": 4,
+        "level": 3,
+        "lft": 218,
+        "tree_id": 90,
+        "bbox_x0": -73.985527,
+        "bbox_x1": -28.839041,
+        "bbox_y0": -33.750702,
+        "bbox_y1": 5.26486
+      }
+    },
+    {
+      "pk": 46,
+      "model": "base.region",
+      "fields": {
+        "rght": 143,
+        "code": "VGB",
+        "name": "British Virgin Islands",
+        "parent": 255,
+        "level": 3,
+        "lft": 142,
+        "tree_id": 90,
+        "bbox_x0": -64.783012,
+        "bbox_x1": -64.268761,
+        "bbox_y0": 18.312731,
+        "bbox_y1": 18.757219
+      }
+    },
+    {
+      "pk": 47,
+      "model": "base.region",
+      "fields": {
+        "rght": 295,
+        "code": "BRN",
+        "name": "Brunei Darussalam",
+        "parent": 7,
+        "level": 3,
+        "lft": 294,
+        "tree_id": 90,
+        "bbox_x0": 114.071457,
+        "bbox_x1": 115.359451,
+        "bbox_y0": 4.00309,
+        "bbox_y1": 5.04717
+      }
+    },
+    {
+      "pk": 48,
+      "model": "base.region",
+      "fields": {
+        "rght": 338,
+        "code": "BGR",
+        "name": "Bulgaria",
+        "parent": 5,
+        "level": 2,
+        "lft": 337,
+        "tree_id": 90,
+        "bbox_x0": 22.35741,
+        "bbox_x1": 28.60882,
+        "bbox_y0": 41.235931,
+        "bbox_y1": 44.227261
+      }
+    },
+    {
+      "pk": 49,
+      "model": "base.region",
+      "fields": {
+        "rght": 89,
+        "code": "BFA",
+        "name": "Burkina Faso",
+        "parent": 13,
+        "level": 3,
+        "lft": 88,
+        "tree_id": 90,
+        "bbox_x0": -5.51891,
+        "bbox_x1": 2.40539,
+        "bbox_y0": 9.4011,
+        "bbox_y1": 15.08259
+      }
+    },
+    {
+      "pk": 50,
+      "model": "base.region",
+      "fields": {
+        "rght": 15,
+        "code": "BDI",
+        "name": "Burundi",
+        "parent": 12,
+        "level": 3,
+        "lft": 14,
+        "tree_id": 90,
+        "bbox_x0": 28.993071,
+        "bbox_x1": 30.847719,
+        "bbox_y0": -4.46571,
+        "bbox_y1": -2.31012
+      }
+    },
+    {
+      "pk": 51,
+      "model": "base.region",
+      "fields": {
+        "rght": 297,
+        "code": "KHM",
+        "name": "Cambodia",
+        "parent": 7,
+        "level": 3,
+        "lft": 296,
+        "tree_id": 90,
+        "bbox_x0": 102.340012,
+        "bbox_x1": 107.627724,
+        "bbox_y0": 9.28325,
+        "bbox_y1": 14.6864
+      }
+    },
+    {
+      "pk": 52,
+      "model": "base.region",
+      "fields": {
+        "rght": 91,
+        "code": "CMR",
+        "name": "Cameroon",
+        "parent": 13,
+        "level": 3,
+        "lft": 90,
+        "tree_id": 90,
+        "bbox_x0": 8.49477,
+        "bbox_x1": 16.19211,
+        "bbox_y0": 1.65254,
+        "bbox_y1": 13.07805
+      }
+    },
+    {
+      "pk": 53,
+      "model": "base.region",
+      "fields": {
+        "rght": 205,
+        "code": "CAN",
+        "name": "Canada",
+        "parent": 2,
+        "level": 3,
+        "lft": 204,
+        "tree_id": 90,
+        "bbox_x0": -141.002701,
+        "bbox_x1": -52.620201,
+        "bbox_y0": 41.681019,
+        "bbox_y1": 83.110619
+      }
+    },
+    {
+      "pk": 54,
+      "model": "base.region",
+      "fields": {
+        "rght": 93,
+        "code": "CPV",
+        "name": "Cape Verde",
+        "parent": 13,
+        "level": 3,
+        "lft": 92,
+        "tree_id": 90,
+        "bbox_x0": -25.35874,
+        "bbox_x1": -22.666201,
+        "bbox_y0": 14.80221,
+        "bbox_y1": 17.19717
+      }
+    },
+    {
+      "pk": 55,
+      "model": "base.region",
+      "fields": {
+        "rght": 145,
+        "code": "CYM",
+        "name": "Cayman Islands",
+        "parent": 255,
+        "level": 3,
+        "lft": 144,
+        "tree_id": 90,
+        "bbox_x0": -81.420593,
+        "bbox_x1": -79.722321,
+        "bbox_y0": 19.262659,
+        "bbox_y1": 19.75738
+      }
+    },
+    {
+      "pk": 56,
+      "model": "base.region",
+      "fields": {
+        "rght": 5,
+        "code": "CAF",
+        "name": "Central African Republic",
+        "parent": 257,
+        "level": 3,
+        "lft": 4,
+        "tree_id": 90,
+        "bbox_x0": 14.42009,
+        "bbox_x1": 27.463421,
+        "bbox_y0": 2.22051,
+        "bbox_y1": 11.00756
+      }
+    },
+    {
+      "pk": 57,
+      "model": "base.region",
+      "fields": {
+        "rght": 7,
+        "code": "TCD",
+        "name": "Chad",
+        "parent": 257,
+        "level": 3,
+        "lft": 6,
+        "tree_id": 90,
+        "bbox_x0": 13.47592,
+        "bbox_x1": 24.00161,
+        "bbox_y0": 7.44237,
+        "bbox_y1": 23.478239
+      }
+    },
+    {
+      "pk": 58,
+      "model": "base.region",
+      "fields": {
+        "rght": 340,
+        "code": "CIL",
+        "name": "Channel Islands",
+        "parent": 5,
+        "level": 2,
+        "lft": 339,
+        "tree_id": 90,
+        "bbox_x0": -2.67545,
+        "bbox_x1": -2.01129,
+        "bbox_y0": 49.16209,
+        "bbox_y1": 49.7393
+      }
+    },
+    {
+      "pk": 59,
+      "model": "base.region",
+      "fields": {
+        "rght": 221,
+        "code": "CHL",
+        "name": "Chile",
+        "parent": 4,
+        "level": 3,
+        "lft": 220,
+        "tree_id": 90,
+        "bbox_x0": -109.47493,
+        "bbox_x1": -66.417549,
+        "bbox_y0": -56.533779,
+        "bbox_y1": -17.507549
+      }
+    },
+    {
+      "pk": 60,
+      "model": "base.region",
+      "fields": {
+        "rght": 263,
+        "code": "CHN",
+        "name": "China",
+        "parent": 258,
+        "level": 3,
+        "lft": 262,
+        "tree_id": 90,
+        "bbox_x0": 73.557701,
+        "bbox_x1": 134.773605,
+        "bbox_y0": 15.77539,
+        "bbox_y1": 53.5606
+      }
+    },
+    {
+      "pk": 61,
+      "model": "base.region",
+      "fields": {
+        "rght": 265,
+        "code": "HKG",
+        "name": "China - Hong Kong",
+        "parent": 258,
+        "level": 3,
+        "lft": 264,
+        "tree_id": 90,
+        "bbox_x0": 113.835083,
+        "bbox_x1": 114.441788,
+        "bbox_y0": 22.153549,
+        "bbox_y1": 22.56204
+      }
+    },
+    {
+      "pk": 62,
+      "model": "base.region",
+      "fields": {
+        "rght": 267,
+        "code": "MAC",
+        "name": "China - Macao",
+        "parent": 258,
+        "level": 3,
+        "lft": 266,
+        "tree_id": 90,
+        "bbox_x0": 113.528351,
+        "bbox_x1": 113.598297,
+        "bbox_y0": 22.10977,
+        "bbox_y1": 22.21697
+      }
+    },
+    {
+      "pk": 63,
+      "model": "base.region",
+      "fields": {
+        "rght": 223,
+        "code": "COL",
+        "name": "Colombia",
+        "parent": 4,
+        "level": 3,
+        "lft": 222,
+        "tree_id": 90,
+        "bbox_x0": -81.728111,
+        "bbox_x1": -66.869827,
+        "bbox_y0": -4.23048,
+        "bbox_y1": 13.39029
+      }
+    },
+    {
+      "pk": 64,
+      "model": "base.region",
+      "fields": {
+        "rght": 17,
+        "code": "COM",
+        "name": "Comoros",
+        "parent": 12,
+        "level": 3,
+        "lft": 16,
+        "tree_id": 90,
+        "bbox_x0": 43.215778,
+        "bbox_x1": 44.538219,
+        "bbox_y0": -12.41382,
+        "bbox_y1": -11.36238
+      }
+    },
+    {
+      "pk": 65,
+      "model": "base.region",
+      "fields": {
+        "rght": 9,
+        "code": "COG",
+        "name": "Congo",
+        "parent": 257,
+        "level": 3,
+        "lft": 8,
+        "tree_id": 90,
+        "bbox_x0": 11.205,
+        "bbox_x1": 18.64983,
+        "bbox_y0": -5.02831,
+        "bbox_y1": 3.70308
+      }
+    },
+    {
+      "pk": 66,
+      "model": "base.region",
+      "fields": {
+        "rght": 470,
+        "code": "COK",
+        "name": "Cook Islands",
+        "parent": 256,
+        "level": 2,
+        "lft": 469,
+        "tree_id": 90,
+        "bbox_x0": -165.858093,
+        "bbox_x1": -157.312119,
+        "bbox_y0": -21.94416,
+        "bbox_y1": -8.94402
+      }
+    },
+    {
+      "pk": 67,
+      "model": "base.region",
+      "fields": {
+        "rght": 191,
+        "code": "CRI",
+        "name": "Costa Rica",
+        "parent": 3,
+        "level": 3,
+        "lft": 190,
+        "tree_id": 90,
+        "bbox_x0": -87.083778,
+        "bbox_x1": -82.556,
+        "bbox_y0": 5.49955,
+        "bbox_y1": 11.21681
+      }
+    },
+    {
+      "pk": 68,
+      "model": "base.region",
+      "fields": {
+        "rght": 95,
+        "code": "CIV",
+        "name": "Cote d'Ivoire",
+        "parent": 13,
+        "level": 3,
+        "lft": 94,
+        "tree_id": 90,
+        "bbox_x0": -8.6017249,
+        "bbox_x1": -2.4930309,
+        "bbox_y0": 4.1642077,
+        "bbox_y1": 10.740015
+      }
+    },
+    {
+      "pk": 69,
+      "model": "base.region",
+      "fields": {
+        "rght": 342,
+        "code": "HRV",
+        "name": "Croatia",
+        "parent": 5,
+        "level": 2,
+        "lft": 341,
+        "tree_id": 90,
+        "bbox_x0": 13.48972,
+        "bbox_x1": 19.44722,
+        "bbox_y0": 42.392208,
+        "bbox_y1": 46.554981
+      }
+    },
+    {
+      "pk": 70,
+      "model": "base.region",
+      "fields": {
+        "rght": 147,
+        "code": "CUB",
+        "name": "Cuba",
+        "parent": 255,
+        "level": 3,
+        "lft": 146,
+        "tree_id": 90,
+        "bbox_x0": -84.957428,
+        "bbox_x1": -74.131783,
+        "bbox_y0": 19.828079,
+        "bbox_y1": 23.283779
+      }
+    },
+    {
+      "pk": 71,
+      "model": "base.region",
+      "fields": {
+        "rght": 344,
+        "code": "CYP",
+        "name": "Cyprus",
+        "parent": 5,
+        "level": 2,
+        "lft": 343,
+        "tree_id": 90,
+        "bbox_x0": 32.27309,
+        "bbox_x1": 34.597919,
+        "bbox_y0": 34.563511,
+        "bbox_y1": 35.701542
+      }
+    },
+    {
+      "pk": 72,
+      "model": "base.region",
+      "fields": {
+        "rght": 346,
+        "code": "CZE",
+        "name": "Czech Republic",
+        "parent": 5,
+        "level": 2,
+        "lft": 345,
+        "tree_id": 90,
+        "bbox_x0": 12.0905901,
+        "bbox_x1": 18.859216,
+        "bbox_y0": 48.5518144,
+        "bbox_y1": 51.0557036
+      }
+    },
+    {
+      "pk": 73,
+      "model": "base.region",
+      "fields": {
+        "rght": 269,
+        "code": "PRK",
+        "name": "Democratic People's Republic of Korea",
+        "parent": 258,
+        "level": 3,
+        "lft": 268,
+        "tree_id": 90,
+        "bbox_x0": 124.182739,
+        "bbox_x1": 130.674713,
+        "bbox_y0": 37.632881,
+        "bbox_y1": 43.006001
+      }
+    },
+    {
+      "pk": 74,
+      "model": "base.region",
+      "fields": {
+        "rght": 11,
+        "code": "COD",
+        "name": "Democratic Republic of the Congo",
+        "parent": 257,
+        "level": 3,
+        "lft": 10,
+        "tree_id": 90,
+        "bbox_x0": 12.20663,
+        "bbox_x1": 31.30591,
+        "bbox_y0": -13.45567,
+        "bbox_y1": 5.38609
+      }
+    },
+    {
+      "pk": 75,
+      "model": "base.region",
+      "fields": {
+        "rght": 348,
+        "code": "DNK",
+        "name": "Denmark",
+        "parent": 5,
+        "level": 2,
+        "lft": 347,
+        "tree_id": 90,
+        "bbox_x0": 8.07472,
+        "bbox_x1": 15.19324,
+        "bbox_y0": 54.559132,
+        "bbox_y1": 57.751949
+      }
+    },
+    {
+      "pk": 76,
+      "model": "base.region",
+      "fields": {
+        "rght": 19,
+        "code": "DJI",
+        "name": "Djibouti",
+        "parent": 12,
+        "level": 3,
+        "lft": 18,
+        "tree_id": 90,
+        "bbox_x0": 41.773441,
+        "bbox_x1": 43.450459,
+        "bbox_y0": 10.90991,
+        "bbox_y1": 12.70683
+      }
+    },
+    {
+      "pk": 77,
+      "model": "base.region",
+      "fields": {
+        "rght": 149,
+        "code": "DMA",
+        "name": "Dominica",
+        "parent": 255,
+        "level": 3,
+        "lft": 148,
+        "tree_id": 90,
+        "bbox_x0": -61.4841,
+        "bbox_x1": -61.244148,
+        "bbox_y0": 15.20168,
+        "bbox_y1": 15.6318
+      }
+    },
+    {
+      "pk": 78,
+      "model": "base.region",
+      "fields": {
+        "rght": 151,
+        "code": "DOM",
+        "name": "Dominican Republic",
+        "parent": 255,
+        "level": 3,
+        "lft": 150,
+        "tree_id": 90,
+        "bbox_x0": -72.003479,
+        "bbox_x1": -68.319992,
+        "bbox_y0": 17.469299,
+        "bbox_y1": 19.92985
+      }
+    },
+    {
+      "pk": 79,
+      "model": "base.region",
+      "fields": {
+        "rght": 225,
+        "code": "ECU",
+        "name": "Ecuador",
+        "parent": 4,
+        "level": 3,
+        "lft": 224,
+        "tree_id": 90,
+        "bbox_x0": -91.66124,
+        "bbox_x1": -75.200073,
+        "bbox_y0": -5.01734,
+        "bbox_y1": 1.45421
+      }
+    },
+    {
+      "pk": 80,
+      "model": "base.region",
+      "fields": {
+        "rght": 53,
+        "code": "EGY",
+        "name": "Egypt",
+        "parent": 11,
+        "level": 3,
+        "lft": 52,
+        "tree_id": 90,
+        "bbox_x0": 24.698099,
+        "bbox_x1": 36.89468,
+        "bbox_y0": 22,
+        "bbox_y1": 31.674179
+      }
+    },
+    {
+      "pk": 81,
+      "model": "base.region",
+      "fields": {
+        "rght": 193,
+        "code": "SLV",
+        "name": "El Salvador",
+        "parent": 3,
+        "level": 3,
+        "lft": 192,
+        "tree_id": 90,
+        "bbox_x0": -90.12867,
+        "bbox_x1": -87.682869,
+        "bbox_y0": 13.14867,
+        "bbox_y1": 14.44506
+      }
+    },
+    {
+      "pk": 82,
+      "model": "base.region",
+      "fields": {
+        "rght": 97,
+        "code": "GNQ",
+        "name": "Equatorial Guinea",
+        "parent": 13,
+        "level": 3,
+        "lft": 96,
+        "tree_id": 90,
+        "bbox_x0": 5.60236,
+        "bbox_x1": 11.33572,
+        "bbox_y0": -1.48378,
+        "bbox_y1": 3.78597
+      }
+    },
+    {
+      "pk": 83,
+      "model": "base.region",
+      "fields": {
+        "rght": 21,
+        "code": "ERI",
+        "name": "Eritrea",
+        "parent": 12,
+        "level": 3,
+        "lft": 20,
+        "tree_id": 90,
+        "bbox_x0": 36.43877,
+        "bbox_x1": 43.14864,
+        "bbox_y0": 12.35956,
+        "bbox_y1": 18.00308
+      }
+    },
+    {
+      "pk": 84,
+      "model": "base.region",
+      "fields": {
+        "rght": 350,
+        "code": "EST",
+        "name": "Estonia",
+        "parent": 5,
+        "level": 2,
+        "lft": 349,
+        "tree_id": 90,
+        "bbox_x0": 21.771851,
+        "bbox_x1": 28.20989,
+        "bbox_y0": 57.509312,
+        "bbox_y1": 59.685749
+      }
+    },
+    {
+      "pk": 85,
+      "model": "base.region",
+      "fields": {
+        "rght": 23,
+        "code": "ETH",
+        "name": "Ethiopia",
+        "parent": 12,
+        "level": 3,
+        "lft": 22,
+        "tree_id": 90,
+        "bbox_x0": 32.99992,
+        "bbox_x1": 47.986172,
+        "bbox_y0": 3.40242,
+        "bbox_y1": 14.89218
+      }
+    },
+    {
+      "pk": 86,
+      "model": "base.region",
+      "fields": {
+        "rght": 352,
+        "code": "FRO",
+        "name": "Faeroe Islands",
+        "parent": 5,
+        "level": 2,
+        "lft": 351,
+        "tree_id": 90,
+        "bbox_x0": -7.68124,
+        "bbox_x1": -6.25861,
+        "bbox_y0": 61.394932,
+        "bbox_y1": 62.400742
+      }
+    },
+    {
+      "pk": 87,
+      "model": "base.region",
+      "fields": {
+        "rght": 227,
+        "code": "FLK",
+        "name": "Falkland Islands (Malvinas)",
+        "parent": 4,
+        "level": 3,
+        "lft": 226,
+        "tree_id": 90,
+        "bbox_x0": -61.43404,
+        "bbox_x1": -57.712479,
+        "bbox_y0": -52.900581,
+        "bbox_y1": -50.966221
+      }
+    },
+    {
+      "pk": 88,
+      "model": "base.region",
+      "fields": {
+        "rght": 472,
+        "code": "FJI",
+        "name": "Fiji",
+        "parent": 256,
+        "level": 2,
+        "lft": 471,
+        "tree_id": 90,
+        "bbox_x0": 174.866196,
+        "bbox_x1": -178.203156,
+        "bbox_y0": -21.01712,
+        "bbox_y1": -12.46622
+      }
+    },
+    {
+      "pk": 89,
+      "model": "base.region",
+      "fields": {
+        "rght": 354,
+        "code": "FIN",
+        "name": "Finland",
+        "parent": 5,
+        "level": 2,
+        "lft": 353,
+        "tree_id": 90,
+        "bbox_x0": 20.548571,
+        "bbox_x1": 31.586201,
+        "bbox_y0": 59.764881,
+        "bbox_y1": 70.092308
+      }
+    },
+    {
+      "pk": 90,
+      "model": "base.region",
+      "fields": {
+        "rght": 356,
+        "code": "FRA",
+        "name": "France",
+        "parent": 5,
+        "level": 2,
+        "lft": 355,
+        "tree_id": 90,
+        "bbox_x0": -5.1406,
+        "bbox_x1": 9.55932,
+        "bbox_y0": 41.33374,
+        "bbox_y1": 51.089062
+      }
+    },
+    {
+      "pk": 91,
+      "model": "base.region",
+      "fields": {
+        "rght": 229,
+        "code": "GUF",
+        "name": "French Guiana",
+        "parent": 4,
+        "level": 3,
+        "lft": 228,
+        "tree_id": 90,
+        "bbox_x0": -54.542511,
+        "bbox_x1": -51.613941,
+        "bbox_y0": 2.12709,
+        "bbox_y1": 5.77649
+      }
+    },
+    {
+      "pk": 92,
+      "model": "base.region",
+      "fields": {
+        "rght": 474,
+        "code": "PYF",
+        "name": "French Polynesia",
+        "parent": 256,
+        "level": 2,
+        "lft": 473,
+        "tree_id": 90,
+        "bbox_x0": -154.700485,
+        "bbox_x1": -108.87291,
+        "bbox_y0": -27.65357,
+        "bbox_y1": 10.35983
+      }
+    },
+    {
+      "pk": 93,
+      "model": "base.region",
+      "fields": {
+        "rght": 99,
+        "code": "GAB",
+        "name": "Gabon",
+        "parent": 13,
+        "level": 3,
+        "lft": 98,
+        "tree_id": 90,
+        "bbox_x0": 8.69547,
+        "bbox_x1": 14.50234,
+        "bbox_y0": -3.9788,
+        "bbox_y1": 2.32261
+      }
+    },
+    {
+      "pk": 94,
+      "model": "base.region",
+      "fields": {
+        "rght": 101,
+        "code": "GMB",
+        "name": "Gambia",
+        "parent": 13,
+        "level": 3,
+        "lft": 100,
+        "tree_id": 90,
+        "bbox_x0": -16.82506,
+        "bbox_x1": -13.7978,
+        "bbox_y0": 13.06425,
+        "bbox_y1": 13.82657
+      }
+    },
+    {
+      "pk": 95,
+      "model": "base.region",
+      "fields": {
+        "rght": 358,
+        "code": "GEO",
+        "name": "Georgia",
+        "parent": 5,
+        "level": 2,
+        "lft": 357,
+        "tree_id": 90,
+        "bbox_x0": 40.01022,
+        "bbox_x1": 46.721359,
+        "bbox_y0": 41.038502,
+        "bbox_y1": 43.584549
+      }
+    },
+    {
+      "pk": 96,
+      "model": "base.region",
+      "fields": {
+        "rght": 360,
+        "code": "DEU",
+        "name": "Germany",
+        "parent": 5,
+        "level": 2,
+        "lft": 359,
+        "tree_id": 90,
+        "bbox_x0": 5.86624,
+        "bbox_x1": 15.04205,
+        "bbox_y0": 47.27021,
+        "bbox_y1": 55.05814
+      }
+    },
+    {
+      "pk": 97,
+      "model": "base.region",
+      "fields": {
+        "rght": 103,
+        "code": "GHA",
+        "name": "Ghana",
+        "parent": 13,
+        "level": 3,
+        "lft": 102,
+        "tree_id": 90,
+        "bbox_x0": -3.25542,
+        "bbox_x1": 1.19178,
+        "bbox_y0": 4.73672,
+        "bbox_y1": 11.1733
+      }
+    },
+    {
+      "pk": 98,
+      "model": "base.region",
+      "fields": {
+        "rght": 362,
+        "code": "GIB",
+        "name": "Gibraltar",
+        "parent": 5,
+        "level": 2,
+        "lft": 361,
+        "tree_id": 90,
+        "bbox_x0": -5.3579,
+        "bbox_x1": -5.33867,
+        "bbox_y0": 36.108219,
+        "bbox_y1": 36.15593
+      }
+    },
+    {
+      "pk": 99,
+      "model": "base.region",
+      "fields": {
+        "rght": 364,
+        "code": "GRC",
+        "name": "Greece",
+        "parent": 5,
+        "level": 2,
+        "lft": 363,
+        "tree_id": 90,
+        "bbox_x0": 19.37431,
+        "bbox_x1": 29.70056,
+        "bbox_y0": 34.809502,
+        "bbox_y1": 41.757111
+      }
+    },
+    {
+      "pk": 100,
+      "model": "base.region",
+      "fields": {
+        "rght": 207,
+        "code": "GRL",
+        "name": "Greenland",
+        "parent": 2,
+        "level": 3,
+        "lft": 206,
+        "tree_id": 90,
+        "bbox_x0": -73.263474,
+        "bbox_x1": -11.31232,
+        "bbox_y0": 59.777271,
+        "bbox_y1": 83.627419
+      }
+    },
+    {
+      "pk": 101,
+      "model": "base.region",
+      "fields": {
+        "rght": 153,
+        "code": "GRD",
+        "name": "Grenada",
+        "parent": 255,
+        "level": 3,
+        "lft": 152,
+        "tree_id": 90,
+        "bbox_x0": -61.79998,
+        "bbox_x1": -61.376362,
+        "bbox_y0": 11.98288,
+        "bbox_y1": 12.5415
+      }
+    },
+    {
+      "pk": 102,
+      "model": "base.region",
+      "fields": {
+        "rght": 155,
+        "code": "GLP",
+        "name": "Guadeloupe",
+        "parent": 255,
+        "level": 3,
+        "lft": 154,
+        "tree_id": 90,
+        "bbox_x0": -61.807159,
+        "bbox_x1": -61,
+        "bbox_y0": 15.83097,
+        "bbox_y1": 16.51684
+      }
+    },
+    {
+      "pk": 103,
+      "model": "base.region",
+      "fields": {
+        "rght": 476,
+        "code": "GUM",
+        "name": "Guam",
+        "parent": 256,
+        "level": 2,
+        "lft": 475,
+        "tree_id": 90,
+        "bbox_x0": 144.619263,
+        "bbox_x1": 144.953995,
+        "bbox_y0": 13.24059,
+        "bbox_y1": 13.65232
+      }
+    },
+    {
+      "pk": 104,
+      "model": "base.region",
+      "fields": {
+        "rght": 195,
+        "code": "GTM",
+        "name": "Guatemala",
+        "parent": 3,
+        "level": 3,
+        "lft": 194,
+        "tree_id": 90,
+        "bbox_x0": -92.241432,
+        "bbox_x1": -88.22319,
+        "bbox_y0": 13.7373,
+        "bbox_y1": 17.815201
+      }
+    },
+    {
+      "pk": 105,
+      "model": "base.region",
+      "fields": {
+        "rght": 366,
+        "code": "GGY",
+        "name": "Guernsey",
+        "parent": 5,
+        "level": 2,
+        "lft": 365,
+        "tree_id": 90,
+        "bbox_x0": -2.67545,
+        "bbox_x1": -2.16382,
+        "bbox_y0": 49.405762,
+        "bbox_y1": 49.7393
+      }
+    },
+    {
+      "pk": 106,
+      "model": "base.region",
+      "fields": {
+        "rght": 105,
+        "code": "GIN",
+        "name": "Guinea",
+        "parent": 13,
+        "level": 3,
+        "lft": 104,
+        "tree_id": 90,
+        "bbox_x0": -15.08625,
+        "bbox_x1": -7.64106,
+        "bbox_y0": 7.19355,
+        "bbox_y1": 12.67621
+      }
+    },
+    {
+      "pk": 107,
+      "model": "base.region",
+      "fields": {
+        "rght": 107,
+        "code": "GNB",
+        "name": "Guinea-Bissau",
+        "parent": 13,
+        "level": 3,
+        "lft": 106,
+        "tree_id": 90,
+        "bbox_x0": -16.717529,
+        "bbox_x1": -13.63652,
+        "bbox_y0": 10.85997,
+        "bbox_y1": 12.68078
+      }
+    },
+    {
+      "pk": 108,
+      "model": "base.region",
+      "fields": {
+        "rght": 231,
+        "code": "GUY",
+        "name": "Guyana",
+        "parent": 4,
+        "level": 3,
+        "lft": 230,
+        "tree_id": 90,
+        "bbox_x0": -61.396271,
+        "bbox_x1": -56.480251,
+        "bbox_y0": 1.17508,
+        "bbox_y1": 8.55756
+      }
+    },
+    {
+      "pk": 109,
+      "model": "base.region",
+      "fields": {
+        "rght": 157,
+        "code": "HTI",
+        "name": "Haiti",
+        "parent": 255,
+        "level": 3,
+        "lft": 156,
+        "tree_id": 90,
+        "bbox_x0": -74.478592,
+        "bbox_x1": -71.61335,
+        "bbox_y0": 18.02103,
+        "bbox_y1": 20.08782
+      }
+    },
+    {
+      "pk": 110,
+      "model": "base.region",
+      "fields": {
+        "rght": 368,
+        "code": "VAT",
+        "name": "Holy See (Vatican City)",
+        "parent": 5,
+        "level": 2,
+        "lft": 367,
+        "tree_id": 90,
+        "bbox_x0": 12.44584,
+        "bbox_x1": 12.45842,
+        "bbox_y0": 41.900211,
+        "bbox_y1": 41.907459
+      }
+    },
+    {
+      "pk": 111,
+      "model": "base.region",
+      "fields": {
+        "rght": 197,
+        "code": "HND",
+        "name": "Honduras",
+        "parent": 3,
+        "level": 3,
+        "lft": 196,
+        "tree_id": 90,
+        "bbox_x0": -89.350792,
+        "bbox_x1": -82.499527,
+        "bbox_y0": 12.98241,
+        "bbox_y1": 17.450451
+      }
+    },
+    {
+      "pk": 112,
+      "model": "base.region",
+      "fields": {
+        "rght": 370,
+        "code": "HUN",
+        "name": "Hungary",
+        "parent": 5,
+        "level": 2,
+        "lft": 369,
+        "tree_id": 90,
+        "bbox_x0": 16.11335,
+        "bbox_x1": 22.89657,
+        "bbox_y0": 45.737061,
+        "bbox_y1": 48.585258
+      }
+    },
+    {
+      "pk": 113,
+      "model": "base.region",
+      "fields": {
+        "rght": 372,
+        "code": "ISL",
+        "name": "Iceland",
+        "parent": 5,
+        "level": 2,
+        "lft": 371,
+        "tree_id": 90,
+        "bbox_x0": -24.54652,
+        "bbox_x1": -13.49416,
+        "bbox_y0": 63.295952,
+        "bbox_y1": 66.566193
+      }
+    },
+    {
+      "pk": 114,
+      "model": "base.region",
+      "fields": {
+        "rght": 283,
+        "code": "IND",
+        "name": "India",
+        "parent": 9,
+        "level": 3,
+        "lft": 282,
+        "tree_id": 90,
+        "bbox_x0": 68.032318,
+        "bbox_x1": 97.403023,
+        "bbox_y0": 6.7471,
+        "bbox_y1": 36.261688
+      }
+    },
+    {
+      "pk": 115,
+      "model": "base.region",
+      "fields": {
+        "rght": 299,
+        "code": "IDN",
+        "name": "Indonesia",
+        "parent": 7,
+        "level": 3,
+        "lft": 298,
+        "tree_id": 90,
+        "bbox_x0": 94.969833,
+        "bbox_x1": 141.021805,
+        "bbox_y0": -11.00485,
+        "bbox_y1": 6.07573
+      }
+    },
+    {
+      "pk": 116,
+      "model": "base.region",
+      "fields": {
+        "rght": 438,
+        "code": "IRN",
+        "name": "Iran",
+        "parent": 15,
+        "level": 2,
+        "lft": 437,
+        "tree_id": 90,
+        "bbox_x0": 44.047249,
+        "bbox_x1": 63.317459,
+        "bbox_y0": 25.064079,
+        "bbox_y1": 39.777222
+      }
+    },
+    {
+      "pk": 117,
+      "model": "base.region",
+      "fields": {
+        "rght": 440,
+        "code": "IRQ",
+        "name": "Iraq",
+        "parent": 15,
+        "level": 2,
+        "lft": 439,
+        "tree_id": 90,
+        "bbox_x0": 38.804001,
+        "bbox_x1": 48.575699,
+        "bbox_y0": 29.103001,
+        "bbox_y1": 37.378052
+      }
+    },
+    {
+      "pk": 118,
+      "model": "base.region",
+      "fields": {
+        "rght": 374,
+        "code": "IRL",
+        "name": "Ireland",
+        "parent": 5,
+        "level": 2,
+        "lft": 373,
+        "tree_id": 90,
+        "bbox_x0": -10.61834,
+        "bbox_x1": -5.9975,
+        "bbox_y0": 51.424511,
+        "bbox_y1": 55.436211
+      }
+    },
+    {
+      "pk": 119,
+      "model": "base.region",
+      "fields": {
+        "rght": 376,
+        "code": "IMN",
+        "name": "Isle of Man",
+        "parent": 5,
+        "level": 2,
+        "lft": 375,
+        "tree_id": 90,
+        "bbox_x0": -4.83018,
+        "bbox_x1": -4.31007,
+        "bbox_y0": 54.04464,
+        "bbox_y1": 54.418839
+      }
+    },
+    {
+      "pk": 120,
+      "model": "base.region",
+      "fields": {
+        "rght": 442,
+        "code": "ISR",
+        "name": "Israel",
+        "parent": 15,
+        "level": 2,
+        "lft": 441,
+        "tree_id": 90,
+        "bbox_x0": 34.2677,
+        "bbox_x1": 35.940941,
+        "bbox_y0": 29.4965,
+        "bbox_y1": 33.43338
+      }
+    },
+    {
+      "pk": 121,
+      "model": "base.region",
+      "fields": {
+        "rght": 378,
+        "code": "ITA",
+        "name": "Italy",
+        "parent": 5,
+        "level": 2,
+        "lft": 377,
+        "tree_id": 90,
+        "bbox_x0": 6.62665,
+        "bbox_x1": 18.520281,
+        "bbox_y0": 35.49308,
+        "bbox_y1": 47.091999
+      }
+    },
+    {
+      "pk": 122,
+      "model": "base.region",
+      "fields": {
+        "rght": 159,
+        "code": "JAM",
+        "name": "Jamaica",
+        "parent": 255,
+        "level": 3,
+        "lft": 158,
+        "tree_id": 90,
+        "bbox_x0": -78.366638,
+        "bbox_x1": -75.982857,
+        "bbox_y0": 16.949551,
+        "bbox_y1": 18.52697
+      }
+    },
+    {
+      "pk": 123,
+      "model": "base.region",
+      "fields": {
+        "rght": 271,
+        "code": "JPN",
+        "name": "Japan",
+        "parent": 258,
+        "level": 3,
+        "lft": 270,
+        "tree_id": 90,
+        "bbox_x0": 122.933647,
+        "bbox_x1": 153.986847,
+        "bbox_y0": 20.4251,
+        "bbox_y1": 45.557709
+      }
+    },
+    {
+      "pk": 124,
+      "model": "base.region",
+      "fields": {
+        "rght": 380,
+        "code": "JEY",
+        "name": "Jersey",
+        "parent": 5,
+        "level": 2,
+        "lft": 379,
+        "tree_id": 90,
+        "bbox_x0": -2.25505,
+        "bbox_x1": -2.01129,
+        "bbox_y0": 49.16209,
+        "bbox_y1": 49.26231
+      }
+    },
+    {
+      "pk": 125,
+      "model": "base.region",
+      "fields": {
+        "rght": 444,
+        "code": "JOR",
+        "name": "Jordan",
+        "parent": 15,
+        "level": 2,
+        "lft": 443,
+        "tree_id": 90,
+        "bbox_x0": 34.960232,
+        "bbox_x1": 39.301128,
+        "bbox_y0": 29.18409,
+        "bbox_y1": 33.374828
+      }
+    },
+    {
+      "pk": 126,
+      "model": "base.region",
+      "fields": {
+        "rght": 251,
+        "code": "KAZ",
+        "name": "Kazakhstan",
+        "parent": 8,
+        "level": 3,
+        "lft": 250,
+        "tree_id": 90,
+        "bbox_x0": 46.491859,
+        "bbox_x1": 87.312737,
+        "bbox_y0": 40.566689,
+        "bbox_y1": 55.431808
+      }
+    },
+    {
+      "pk": 127,
+      "model": "base.region",
+      "fields": {
+        "rght": 25,
+        "code": "KEN",
+        "name": "Kenya",
+        "parent": 12,
+        "level": 3,
+        "lft": 24,
+        "tree_id": 90,
+        "bbox_x0": 33.90884,
+        "bbox_x1": 41.899059,
+        "bbox_y0": -4.71712,
+        "bbox_y1": 4.62933
+      }
+    },
+    {
+      "pk": 128,
+      "model": "base.region",
+      "fields": {
+        "rght": 478,
+        "code": "KIR",
+        "name": "Kiribati",
+        "parent": 256,
+        "level": 2,
+        "lft": 477,
+        "tree_id": 90,
+        "bbox_x0": 158.418335,
+        "bbox_x1": -150.208359,
+        "bbox_y0": -11.43703,
+        "bbox_y1": 4.71956
+      }
+    },
+    {
+      "pk": 129,
+      "model": "base.region",
+      "fields": {
+        "rght": 446,
+        "code": "KWT",
+        "name": "Kuwait",
+        "parent": 15,
+        "level": 2,
+        "lft": 445,
+        "tree_id": 90,
+        "bbox_x0": 46.55751,
+        "bbox_x1": 48.78384,
+        "bbox_y0": 28.5245,
+        "bbox_y1": 30.0958
+      }
+    },
+    {
+      "pk": 130,
+      "model": "base.region",
+      "fields": {
+        "rght": 253,
+        "code": "KGZ",
+        "name": "Kyrgyzstan",
+        "parent": 8,
+        "level": 3,
+        "lft": 252,
+        "tree_id": 90,
+        "bbox_x0": 69.276619,
+        "bbox_x1": 80.28318,
+        "bbox_y0": 39.17284,
+        "bbox_y1": 43.238239
+      }
+    },
+    {
+      "pk": 131,
+      "model": "base.region",
+      "fields": {
+        "rght": 301,
+        "code": "LAO",
+        "name": "Lao People's Democratic Republic",
+        "parent": 7,
+        "level": 3,
+        "lft": 300,
+        "tree_id": 90,
+        "bbox_x0": 100.093048,
+        "bbox_x1": 107.697021,
+        "bbox_y0": 13.91002,
+        "bbox_y1": 22.500389
+      }
+    },
+    {
+      "pk": 132,
+      "model": "base.region",
+      "fields": {
+        "rght": 382,
+        "code": "LVA",
+        "name": "Latvia",
+        "parent": 5,
+        "level": 2,
+        "lft": 381,
+        "tree_id": 90,
+        "bbox_x0": 20.966061,
+        "bbox_x1": 28.244431,
+        "bbox_y0": 55.67276,
+        "bbox_y1": 58.087448
+      }
+    },
+    {
+      "pk": 133,
+      "model": "base.region",
+      "fields": {
+        "rght": 448,
+        "code": "LBN",
+        "name": "Lebanon",
+        "parent": 15,
+        "level": 2,
+        "lft": 447,
+        "tree_id": 90,
+        "bbox_x0": 35.10368,
+        "bbox_x1": 36.622791,
+        "bbox_y0": 33.048908,
+        "bbox_y1": 34.69268
+      }
+    },
+    {
+      "pk": 134,
+      "model": "base.region",
+      "fields": {
+        "rght": 69,
+        "code": "LSO",
+        "name": "Lesotho",
+        "parent": 14,
+        "level": 3,
+        "lft": 68,
+        "tree_id": 90,
+        "bbox_x0": 27.02906,
+        "bbox_x1": 29.465771,
+        "bbox_y0": -30.668961,
+        "bbox_y1": -28.57205
+      }
+    },
+    {
+      "pk": 135,
+      "model": "base.region",
+      "fields": {
+        "rght": 109,
+        "code": "LBR",
+        "name": "Liberia",
+        "parent": 13,
+        "level": 3,
+        "lft": 108,
+        "tree_id": 90,
+        "bbox_x0": -11.49208,
+        "bbox_x1": -7.36511,
+        "bbox_y0": 4.35305,
+        "bbox_y1": 8.55179
+      }
+    },
+    {
+      "pk": 136,
+      "model": "base.region",
+      "fields": {
+        "rght": 55,
+        "code": "LBY",
+        "name": "Libyan Arab Jamahiriya",
+        "parent": 11,
+        "level": 3,
+        "lft": 54,
+        "tree_id": 90,
+        "bbox_x0": 9.38702,
+        "bbox_x1": 25.15061,
+        "bbox_y0": 19.508039,
+        "bbox_y1": 33.168999
+      }
+    },
+    {
+      "pk": 137,
+      "model": "base.region",
+      "fields": {
+        "rght": 384,
+        "code": "LIE",
+        "name": "Liechtenstein",
+        "parent": 5,
+        "level": 2,
+        "lft": 383,
+        "tree_id": 90,
+        "bbox_x0": 9.47181,
+        "bbox_x1": 9.63578,
+        "bbox_y0": 47.04834,
+        "bbox_y1": 47.270649
+      }
+    },
+    {
+      "pk": 138,
+      "model": "base.region",
+      "fields": {
+        "rght": 386,
+        "code": "LTU",
+        "name": "Lithuania",
+        "parent": 5,
+        "level": 2,
+        "lft": 385,
+        "tree_id": 90,
+        "bbox_x0": 20.953199,
+        "bbox_x1": 26.835581,
+        "bbox_y0": 53.89748,
+        "bbox_y1": 56.450432
+      }
+    },
+    {
+      "pk": 139,
+      "model": "base.region",
+      "fields": {
+        "rght": 388,
+        "code": "LUX",
+        "name": "Luxembourg",
+        "parent": 5,
+        "level": 2,
+        "lft": 387,
+        "tree_id": 90,
+        "bbox_x0": 5.73579,
+        "bbox_x1": 6.53117,
+        "bbox_y0": 49.447689,
+        "bbox_y1": 50.182751
+      }
+    },
+    {
+      "pk": 140,
+      "model": "base.region",
+      "fields": {
+        "rght": 390,
+        "code": "MKD",
+        "name": "Macedonia",
+        "parent": 5,
+        "level": 2,
+        "lft": 389,
+        "tree_id": 90,
+        "bbox_x0": 20.4645,
+        "bbox_x1": 23.038071,
+        "bbox_y0": 40.860111,
+        "bbox_y1": 42.345501
+      }
+    },
+    {
+      "pk": 141,
+      "model": "base.region",
+      "fields": {
+        "rght": 27,
+        "code": "MDG",
+        "name": "Madagascar",
+        "parent": 12,
+        "level": 3,
+        "lft": 26,
+        "tree_id": 90,
+        "bbox_x0": 43.19138,
+        "bbox_x1": 50.483799,
+        "bbox_y0": -25.60894,
+        "bbox_y1": -11.94543
+      }
+    },
+    {
+      "pk": 142,
+      "model": "base.region",
+      "fields": {
+        "rght": 29,
+        "code": "MWI",
+        "name": "Malawi",
+        "parent": 12,
+        "level": 3,
+        "lft": 28,
+        "tree_id": 90,
+        "bbox_x0": 32.668991,
+        "bbox_x1": 35.920441,
+        "bbox_y0": -17.129459,
+        "bbox_y1": -9.36468
+      }
+    },
+    {
+      "pk": 143,
+      "model": "base.region",
+      "fields": {
+        "rght": 303,
+        "code": "MYS",
+        "name": "Malaysia",
+        "parent": 7,
+        "level": 3,
+        "lft": 302,
+        "tree_id": 90,
+        "bbox_x0": 98.935059,
+        "bbox_x1": 119.448433,
+        "bbox_y0": 0.66364,
+        "bbox_y1": 7.58378
+      }
+    },
+    {
+      "pk": 144,
+      "model": "base.region",
+      "fields": {
+        "rght": 285,
+        "code": "MDV",
+        "name": "Maldives",
+        "parent": 9,
+        "level": 3,
+        "lft": 284,
+        "tree_id": 90,
+        "bbox_x0": 72.616219,
+        "bbox_x1": 73.76712,
+        "bbox_y0": -2.90045,
+        "bbox_y1": 7.11712
+      }
+    },
+    {
+      "pk": 145,
+      "model": "base.region",
+      "fields": {
+        "rght": 111,
+        "code": "MLI",
+        "name": "Mali",
+        "parent": 13,
+        "level": 3,
+        "lft": 110,
+        "tree_id": 90,
+        "bbox_x0": -12.24261,
+        "bbox_x1": 4.24495,
+        "bbox_y0": 10.15951,
+        "bbox_y1": 25
+      }
+    },
+    {
+      "pk": 146,
+      "model": "base.region",
+      "fields": {
+        "rght": 392,
+        "code": "MLT",
+        "name": "Malta",
+        "parent": 5,
+        "level": 2,
+        "lft": 391,
+        "tree_id": 90,
+        "bbox_x0": 14.18341,
+        "bbox_x1": 14.5766,
+        "bbox_y0": 35.786282,
+        "bbox_y1": 36.081821
+      }
+    },
+    {
+      "pk": 147,
+      "model": "base.region",
+      "fields": {
+        "rght": 480,
+        "code": "MHL",
+        "name": "Marshall Islands",
+        "parent": 256,
+        "level": 2,
+        "lft": 479,
+        "tree_id": 90,
+        "bbox_x0": 162.143265,
+        "bbox_x1": 172.161987,
+        "bbox_y0": 4.57487,
+        "bbox_y1": 14.65516
+      }
+    },
+    {
+      "pk": 148,
+      "model": "base.region",
+      "fields": {
+        "rght": 161,
+        "code": "MTQ",
+        "name": "Martinique",
+        "parent": 255,
+        "level": 3,
+        "lft": 160,
+        "tree_id": 90,
+        "bbox_x0": -61.23011,
+        "bbox_x1": -60.81551,
+        "bbox_y0": 14.38244,
+        "bbox_y1": 14.87881
+      }
+    },
+    {
+      "pk": 149,
+      "model": "base.region",
+      "fields": {
+        "rght": 113,
+        "code": "MRT",
+        "name": "Mauritania",
+        "parent": 13,
+        "level": 3,
+        "lft": 112,
+        "tree_id": 90,
+        "bbox_x0": -17.066521,
+        "bbox_x1": -4.8352,
+        "bbox_y0": 14.71554,
+        "bbox_y1": 27.298071
+      }
+    },
+    {
+      "pk": 150,
+      "model": "base.region",
+      "fields": {
+        "rght": 31,
+        "code": "MUS",
+        "name": "Mauritius",
+        "parent": 12,
+        "level": 3,
+        "lft": 30,
+        "tree_id": 90,
+        "bbox_x0": 56.512711,
+        "bbox_x1": 63.525379,
+        "bbox_y0": -20.525709,
+        "bbox_y1": -10.31925
+      }
+    },
+    {
+      "pk": 151,
+      "model": "base.region",
+      "fields": {
+        "rght": 33,
+        "code": "MYT",
+        "name": "Mayotte",
+        "parent": 12,
+        "level": 3,
+        "lft": 32,
+        "tree_id": 90,
+        "bbox_x0": 45.01461,
+        "bbox_x1": 45.317131,
+        "bbox_y0": -13.00045,
+        "bbox_y1": -12.63383
+      }
+    },
+    {
+      "pk": 152,
+      "model": "base.region",
+      "fields": {
+        "rght": 209,
+        "code": "MEX",
+        "name": "Mexico",
+        "parent": 2,
+        "level": 3,
+        "lft": 208,
+        "tree_id": 90,
+        "bbox_x0": -118.867172,
+        "bbox_x1": -86.703392,
+        "bbox_y0": 14.53285,
+        "bbox_y1": 32.71862
+      }
+    },
+    {
+      "pk": 153,
+      "model": "base.region",
+      "fields": {
+        "rght": 482,
+        "code": "FSM",
+        "name": "Micronesia, Federated States of",
+        "parent": 256,
+        "level": 2,
+        "lft": 481,
+        "tree_id": 90,
+        "bbox_x0": 138.052856,
+        "bbox_x1": 163.034912,
+        "bbox_y0": 5.25984,
+        "bbox_y1": 10.02222
+      }
+    },
+    {
+      "pk": 154,
+      "model": "base.region",
+      "fields": {
+        "rght": 394,
+        "code": "MCO",
+        "name": "Monaco",
+        "parent": 5,
+        "level": 2,
+        "lft": 393,
+        "tree_id": 90,
+        "bbox_x0": 7.4091,
+        "bbox_x1": 7.43948,
+        "bbox_y0": 43.724789,
+        "bbox_y1": 43.7519
+      }
+    },
+    {
+      "pk": 155,
+      "model": "base.region",
+      "fields": {
+        "rght": 273,
+        "code": "MNG",
+        "name": "Mongolia",
+        "parent": 258,
+        "level": 3,
+        "lft": 272,
+        "tree_id": 90,
+        "bbox_x0": 87.749496,
+        "bbox_x1": 119.92411,
+        "bbox_y0": 41.567501,
+        "bbox_y1": 52.154099
+      }
+    },
+    {
+      "pk": 156,
+      "model": "base.region",
+      "fields": {
+        "rght": 396,
+        "code": "MNE",
+        "name": "Montenegro",
+        "parent": 5,
+        "level": 2,
+        "lft": 395,
+        "tree_id": 90,
+        "bbox_x0": 18.43705,
+        "bbox_x1": 20.41608,
+        "bbox_y0": 41.84808,
+        "bbox_y1": 43.542912
+      }
+    },
+    {
+      "pk": 157,
+      "model": "base.region",
+      "fields": {
+        "rght": 163,
+        "code": "MSR",
+        "name": "Montserrat",
+        "parent": 255,
+        "level": 3,
+        "lft": 162,
+        "tree_id": 90,
+        "bbox_x0": -62.24258,
+        "bbox_x1": -62.14642,
+        "bbox_y0": 16.671,
+        "bbox_y1": 16.81732
+      }
+    },
+    {
+      "pk": 158,
+      "model": "base.region",
+      "fields": {
+        "rght": 57,
+        "code": "MAR",
+        "name": "Morocco",
+        "parent": 11,
+        "level": 3,
+        "lft": 56,
+        "tree_id": 90,
+        "bbox_x0": -11.7805,
+        "bbox_x1": -1.02441,
+        "bbox_y0": 26.946489,
+        "bbox_y1": 35.921909
+      }
+    },
+    {
+      "pk": 159,
+      "model": "base.region",
+      "fields": {
+        "rght": 35,
+        "code": "MOZ",
+        "name": "Mozambique",
+        "parent": 12,
+        "level": 3,
+        "lft": 34,
+        "tree_id": 90,
+        "bbox_x0": 30.21731,
+        "bbox_x1": 40.844471,
+        "bbox_y0": -26.868679,
+        "bbox_y1": -10.47188
+      }
+    },
+    {
+      "pk": 160,
+      "model": "base.region",
+      "fields": {
+        "rght": 305,
+        "code": "MMR",
+        "name": "Myanmar",
+        "parent": 7,
+        "level": 3,
+        "lft": 304,
+        "tree_id": 90,
+        "bbox_x0": 92.189209,
+        "bbox_x1": 101.176788,
+        "bbox_y0": 9.60035,
+        "bbox_y1": 28.543249
+      }
+    },
+    {
+      "pk": 161,
+      "model": "base.region",
+      "fields": {
+        "rght": 71,
+        "code": "NMB",
+        "name": "Namibia",
+        "parent": 14,
+        "level": 3,
+        "lft": 70,
+        "tree_id": 90,
+        "bbox_x0": 11.71563,
+        "bbox_x1": 25.256701,
+        "bbox_y0": -28.97142,
+        "bbox_y1": -16.95989
+      }
+    },
+    {
+      "pk": 162,
+      "model": "base.region",
+      "fields": {
+        "rght": 484,
+        "code": "NRU",
+        "name": "Nauru",
+        "parent": 256,
+        "level": 2,
+        "lft": 483,
+        "tree_id": 90,
+        "bbox_x0": 166.899017,
+        "bbox_x1": 166.945267,
+        "bbox_y0": -0.55232,
+        "bbox_y1": -0.50429
+      }
+    },
+    {
+      "pk": 163,
+      "model": "base.region",
+      "fields": {
+        "rght": 287,
+        "code": "NPL",
+        "name": "Nepal",
+        "parent": 9,
+        "level": 3,
+        "lft": 286,
+        "tree_id": 90,
+        "bbox_x0": 80.056221,
+        "bbox_x1": 88.199318,
+        "bbox_y0": 26.356501,
+        "bbox_y1": 30.433001
+      }
+    },
+    {
+      "pk": 164,
+      "model": "base.region",
+      "fields": {
+        "rght": 398,
+        "code": "NLD",
+        "name": "Netherlands",
+        "parent": 5,
+        "level": 2,
+        "lft": 397,
+        "tree_id": 90,
+        "bbox_x0": 3.35794,
+        "bbox_x1": 7.2267,
+        "bbox_y0": 50.750401,
+        "bbox_y1": 53.554241
+      }
+    },
+    {
+      "pk": 165,
+      "model": "base.region",
+      "fields": {
+        "rght": 165,
+        "code": "NAN",
+        "name": "Netherlands Antilles",
+        "parent": 255,
+        "level": 3,
+        "lft": 164,
+        "tree_id": 90,
+        "bbox_x0": -69.157188,
+        "bbox_x1": -62.943661,
+        "bbox_y0": 11.97318,
+        "bbox_y1": 18.07024
+      }
+    },
+    {
+      "pk": 166,
+      "model": "base.region",
+      "fields": {
+        "rght": 486,
+        "code": "NCL",
+        "name": "New Caledonia",
+        "parent": 256,
+        "level": 2,
+        "lft": 485,
+        "tree_id": 90,
+        "bbox_x0": 158.332855,
+        "bbox_x1": 172.061417,
+        "bbox_y0": -22.90045,
+        "bbox_y1": -18.01622
+      }
+    },
+    {
+      "pk": 167,
+      "model": "base.region",
+      "fields": {
+        "rght": 488,
+        "code": "NZL",
+        "name": "New Zealand",
+        "parent": 256,
+        "level": 2,
+        "lft": 487,
+        "tree_id": 90,
+        "bbox_x0": 165.883804,
+        "bbox_x1": -175.987198,
+        "bbox_y0": -52.618591,
+        "bbox_y1": -29.20997
+      }
+    },
+    {
+      "pk": 168,
+      "model": "base.region",
+      "fields": {
+        "rght": 199,
+        "code": "NIC",
+        "name": "Nicaragua",
+        "parent": 3,
+        "level": 3,
+        "lft": 198,
+        "tree_id": 90,
+        "bbox_x0": -87.6903,
+        "bbox_x1": -82.592072,
+        "bbox_y0": 10.70754,
+        "bbox_y1": 15.0259
+      }
+    },
+    {
+      "pk": 169,
+      "model": "base.region",
+      "fields": {
+        "rght": 115,
+        "code": "NER",
+        "name": "Niger",
+        "parent": 13,
+        "level": 3,
+        "lft": 114,
+        "tree_id": 90,
+        "bbox_x0": 0.16625,
+        "bbox_x1": 15.99564,
+        "bbox_y0": 11.69697,
+        "bbox_y1": 23.525021
+      }
+    },
+    {
+      "pk": 170,
+      "model": "base.region",
+      "fields": {
+        "rght": 117,
+        "code": "NGA",
+        "name": "Nigeria",
+        "parent": 13,
+        "level": 3,
+        "lft": 116,
+        "tree_id": 90,
+        "bbox_x0": 2.66844,
+        "bbox_x1": 14.68006,
+        "bbox_y0": 4.27714,
+        "bbox_y1": 13.892
+      }
+    },
+    {
+      "pk": 171,
+      "model": "base.region",
+      "fields": {
+        "rght": 490,
+        "code": "NIU",
+        "name": "Niue",
+        "parent": 256,
+        "level": 2,
+        "lft": 489,
+        "tree_id": 90,
+        "bbox_x0": -169.951004,
+        "bbox_x1": -169.775177,
+        "bbox_y0": -19.152189,
+        "bbox_y1": -18.951059
+      }
+    },
+    {
+      "pk": 172,
+      "model": "base.region",
+      "fields": {
+        "rght": 492,
+        "code": "NFK",
+        "name": "Norfolk Island",
+        "parent": 256,
+        "level": 2,
+        "lft": 491,
+        "tree_id": 90,
+        "bbox_x0": 167.949493,
+        "bbox_x1": 168.091614,
+        "bbox_y0": -29.11937,
+        "bbox_y1": -28.99493
+      }
+    },
+    {
+      "pk": 173,
+      "model": "base.region",
+      "fields": {
+        "rght": 494,
+        "code": "MNP",
+        "name": "Northern Mariana Islands",
+        "parent": 256,
+        "level": 2,
+        "lft": 493,
+        "tree_id": 90,
+        "bbox_x0": 136.082855,
+        "bbox_x1": 146.081223,
+        "bbox_y0": 14.10735,
+        "bbox_y1": 20.41712
+      }
+    },
+    {
+      "pk": 174,
+      "model": "base.region",
+      "fields": {
+        "rght": 400,
+        "code": "NOR",
+        "name": "Norway",
+        "parent": 5,
+        "level": 2,
+        "lft": 399,
+        "tree_id": 90,
+        "bbox_x0": 4.43292,
+        "bbox_x1": 31.168409,
+        "bbox_y0": 57.962582,
+        "bbox_y1": 71.185509
+      }
+    },
+    {
+      "pk": 175,
+      "model": "base.region",
+      "fields": {
+        "rght": 450,
+        "code": "PSE",
+        "name": "Occupied Palestinian Territory",
+        "parent": 15,
+        "level": 2,
+        "lft": 449,
+        "tree_id": 90,
+        "bbox_x0": 34.230461,
+        "bbox_x1": 35.876499,
+        "bbox_y0": 31.223499,
+        "bbox_y1": 33.340099
+      }
+    },
+    {
+      "pk": 176,
+      "model": "base.region",
+      "fields": {
+        "rght": 452,
+        "code": "OMN",
+        "name": "Oman",
+        "parent": 15,
+        "level": 2,
+        "lft": 451,
+        "tree_id": 90,
+        "bbox_x0": 51.882011,
+        "bbox_x1": 59.83651,
+        "bbox_y0": 16.6457,
+        "bbox_y1": 26.50045
+      }
+    },
+    {
+      "pk": 177,
+      "model": "base.region",
+      "fields": {
+        "rght": 289,
+        "code": "PAK",
+        "name": "Pakistan",
+        "parent": 9,
+        "level": 3,
+        "lft": 288,
+        "tree_id": 90,
+        "bbox_x0": 60.87859,
+        "bbox_x1": 77.840813,
+        "bbox_y0": 23.786699,
+        "bbox_y1": 37.097
+      }
+    },
+    {
+      "pk": 178,
+      "model": "base.region",
+      "fields": {
+        "rght": 496,
+        "code": "PLW",
+        "name": "Palau",
+        "parent": 256,
+        "level": 2,
+        "lft": 495,
+        "tree_id": 90,
+        "bbox_x0": 131.169235,
+        "bbox_x1": 134.723724,
+        "bbox_y0": 3.00114,
+        "bbox_y1": 8.09291
+      }
+    },
+    {
+      "pk": 179,
+      "model": "base.region",
+      "fields": {
+        "rght": 201,
+        "code": "PAN",
+        "name": "Panama",
+        "parent": 3,
+        "level": 3,
+        "lft": 200,
+        "tree_id": 90,
+        "bbox_x0": -83.051453,
+        "bbox_x1": -77.17411,
+        "bbox_y0": 7.1979,
+        "bbox_y1": 9.65045
+      }
+    },
+    {
+      "pk": 180,
+      "model": "base.region",
+      "fields": {
+        "rght": 498,
+        "code": "PNG",
+        "name": "Papua New Guinea",
+        "parent": 256,
+        "level": 2,
+        "lft": 497,
+        "tree_id": 90,
+        "bbox_x0": 140.842865,
+        "bbox_x1": 159.48378,
+        "bbox_y0": -11.65785,
+        "bbox_y1": -0.86622
+      }
+    },
+    {
+      "pk": 181,
+      "model": "base.region",
+      "fields": {
+        "rght": 233,
+        "code": "PRY",
+        "name": "Paraguay",
+        "parent": 4,
+        "level": 3,
+        "lft": 232,
+        "tree_id": 90,
+        "bbox_x0": -62.647072,
+        "bbox_x1": -54.25935,
+        "bbox_y0": -27.60873,
+        "bbox_y1": -19.294041
+      }
+    },
+    {
+      "pk": 182,
+      "model": "base.region",
+      "fields": {
+        "rght": 235,
+        "code": "PER",
+        "name": "Peru",
+        "parent": 4,
+        "level": 3,
+        "lft": 234,
+        "tree_id": 90,
+        "bbox_x0": -81.326736,
+        "bbox_x1": -68.677979,
+        "bbox_y0": -18.34972,
+        "bbox_y1": -0.01297
+      }
+    },
+    {
+      "pk": 183,
+      "model": "base.region",
+      "fields": {
+        "rght": 307,
+        "code": "PHL",
+        "name": "Philippines",
+        "parent": 7,
+        "level": 3,
+        "lft": 306,
+        "tree_id": 90,
+        "bbox_x0": 116.812721,
+        "bbox_x1": 126.856628,
+        "bbox_y0": 4.46811,
+        "bbox_y1": 21.23415
+      }
+    },
+    {
+      "pk": 184,
+      "model": "base.region",
+      "fields": {
+        "rght": 500,
+        "code": "PCN",
+        "name": "Pitcairn",
+        "parent": 256,
+        "level": 2,
+        "lft": 499,
+        "tree_id": 90,
+        "bbox_x0": -130.746033,
+        "bbox_x1": -124.772842,
+        "bbox_y0": -25.07752,
+        "bbox_y1": -23.917271
+      }
+    },
+    {
+      "pk": 185,
+      "model": "base.region",
+      "fields": {
+        "rght": 402,
+        "code": "POL",
+        "name": "Poland",
+        "parent": 5,
+        "level": 2,
+        "lft": 401,
+        "tree_id": 90,
+        "bbox_x0": 14.12281,
+        "bbox_x1": 24.145781,
+        "bbox_y0": 49.002022,
+        "bbox_y1": 54.835812
+      }
+    },
+    {
+      "pk": 186,
+      "model": "base.region",
+      "fields": {
+        "rght": 404,
+        "code": "PRT",
+        "name": "Portugal",
+        "parent": 5,
+        "level": 2,
+        "lft": 403,
+        "tree_id": 90,
+        "bbox_x0": -31.266001,
+        "bbox_x1": -6.18931,
+        "bbox_y0": 30.028061,
+        "bbox_y1": 42.154121
+      }
+    },
+    {
+      "pk": 187,
+      "model": "base.region",
+      "fields": {
+        "rght": 167,
+        "code": "PRI",
+        "name": "Puerto Rico",
+        "parent": 255,
+        "level": 3,
+        "lft": 166,
+        "tree_id": 90,
+        "bbox_x0": -67.942719,
+        "bbox_x1": -65.219978,
+        "bbox_y0": 17.883039,
+        "bbox_y1": 18.520161
+      }
+    },
+    {
+      "pk": 188,
+      "model": "base.region",
+      "fields": {
+        "rght": 454,
+        "code": "QAT",
+        "name": "Qatar",
+        "parent": 15,
+        "level": 2,
+        "lft": 453,
+        "tree_id": 90,
+        "bbox_x0": 50.757011,
+        "bbox_x1": 52.427509,
+        "bbox_y0": 24.482901,
+        "bbox_y1": 26.177509
+      }
+    },
+    {
+      "pk": 189,
+      "model": "base.region",
+      "fields": {
+        "rght": 275,
+        "code": "KOR",
+        "name": "Republic of Korea",
+        "parent": 258,
+        "level": 3,
+        "lft": 274,
+        "tree_id": 90,
+        "bbox_x0": 124.608147,
+        "bbox_x1": 130.933899,
+        "bbox_y0": 33.10611,
+        "bbox_y1": 38.612301
+      }
+    },
+    {
+      "pk": 190,
+      "model": "base.region",
+      "fields": {
+        "rght": 406,
+        "code": "MDA",
+        "name": "Republic of Moldova",
+        "parent": 5,
+        "level": 2,
+        "lft": 405,
+        "tree_id": 90,
+        "bbox_x0": 26.618879,
+        "bbox_x1": 30.16374,
+        "bbox_y0": 45.468498,
+        "bbox_y1": 48.490162
+      }
+    },
+    {
+      "pk": 191,
+      "model": "base.region",
+      "fields": {
+        "rght": 37,
+        "code": "REU",
+        "name": "Reunion",
+        "parent": 12,
+        "level": 3,
+        "lft": 36,
+        "tree_id": 90,
+        "bbox_x0": 55.219082,
+        "bbox_x1": 55.845039,
+        "bbox_y0": -21.37221,
+        "bbox_y1": -20.85685
+      }
+    },
+    {
+      "pk": 192,
+      "model": "base.region",
+      "fields": {
+        "rght": 408,
+        "code": "ROU",
+        "name": "Romania",
+        "parent": 5,
+        "level": 2,
+        "lft": 407,
+        "tree_id": 90,
+        "bbox_x0": 20.269791,
+        "bbox_x1": 29.691,
+        "bbox_y0": 43.626999,
+        "bbox_y1": 48.266891
+      }
+    },
+    {
+      "pk": 193,
+      "model": "base.region",
+      "fields": {
+        "rght": 410,
+        "code": "RUS",
+        "name": "Russian Federation",
+        "parent": 5,
+        "level": 2,
+        "lft": 409,
+        "tree_id": 90,
+        "bbox_x0": 19.638861,
+        "bbox_x1": 180,
+        "bbox_y0": 41.185902,
+        "bbox_y1": 81.856903
+      }
+    },
+    {
+      "pk": 194,
+      "model": "base.region",
+      "fields": {
+        "rght": 39,
+        "code": "RWA",
+        "name": "Rwanda",
+        "parent": 12,
+        "level": 3,
+        "lft": 38,
+        "tree_id": 90,
+        "bbox_x0": 28.8568,
+        "bbox_x1": 30.89596,
+        "bbox_y0": -2.84067,
+        "bbox_y1": -1.05348
+      }
+    },
+    {
+      "pk": 195,
+      "model": "base.region",
+      "fields": {
+        "rght": 73,
+        "code": "SHN",
+        "name": "Saint Helena",
+        "parent": 14,
+        "level": 3,
+        "lft": 72,
+        "tree_id": 90,
+        "bbox_x0": -14.44153,
+        "bbox_x1": -5.63286,
+        "bbox_y0": -40.400452,
+        "bbox_y1": -7.87757
+      }
+    },
+    {
+      "pk": 196,
+      "model": "base.region",
+      "fields": {
+        "rght": 169,
+        "code": "KNA",
+        "name": "Saint Kitts and Nevis",
+        "parent": 255,
+        "level": 3,
+        "lft": 168,
+        "tree_id": 90,
+        "bbox_x0": -62.86956,
+        "bbox_x1": -62.543259,
+        "bbox_y0": 17.095341,
+        "bbox_y1": 17.420111
+      }
+    },
+    {
+      "pk": 197,
+      "model": "base.region",
+      "fields": {
+        "rght": 171,
+        "code": "LCA",
+        "name": "Saint Lucia",
+        "parent": 255,
+        "level": 3,
+        "lft": 170,
+        "tree_id": 90,
+        "bbox_x0": -61.07415,
+        "bbox_x1": -60.866051,
+        "bbox_y0": 13.70477,
+        "bbox_y1": 14.10324
+      }
+    },
+    {
+      "pk": 198,
+      "model": "base.region",
+      "fields": {
+        "rght": 173,
+        "code": "SPM",
+        "name": "Saint Pierre and Miquelon",
+        "parent": 255,
+        "level": 3,
+        "lft": 172,
+        "tree_id": 90,
+        "bbox_x0": -56.420658,
+        "bbox_x1": -56.157372,
+        "bbox_y0": 46.753269,
+        "bbox_y1": 47.14629
+      }
+    },
+    {
+      "pk": 199,
+      "model": "base.region",
+      "fields": {
+        "rght": 175,
+        "code": "VCT",
+        "name": "Saint Vincent and the Grenadines",
+        "parent": 255,
+        "level": 3,
+        "lft": 174,
+        "tree_id": 90,
+        "bbox_x0": -61.459251,
+        "bbox_x1": -61.11388,
+        "bbox_y0": 12.58101,
+        "bbox_y1": 13.37783
+      }
+    },
+    {
+      "pk": 200,
+      "model": "base.region",
+      "fields": {
+        "rght": 177,
+        "code": "BLM",
+        "name": "Saint-Barthelemy",
+        "parent": 255,
+        "level": 3,
+        "lft": 176,
+        "tree_id": 90,
+        "bbox_x0": -62.9338,
+        "bbox_x1": -62.78286,
+        "bbox_y0": 17.86622,
+        "bbox_y1": 17.968599
+      }
+    },
+    {
+      "pk": 201,
+      "model": "base.region",
+      "fields": {
+        "rght": 179,
+        "code": "MAF",
+        "name": "Saint-Martin (French part)",
+        "parent": 255,
+        "level": 3,
+        "lft": 178,
+        "tree_id": 90,
+        "bbox_x0": -63.15276,
+        "bbox_x1": -62.972778,
+        "bbox_y0": 18.052231,
+        "bbox_y1": 18.13069
+      }
+    },
+    {
+      "pk": 202,
+      "model": "base.region",
+      "fields": {
+        "rght": 502,
+        "code": "WSM",
+        "name": "Samoa",
+        "parent": 256,
+        "level": 2,
+        "lft": 501,
+        "tree_id": 90,
+        "bbox_x0": -172.798584,
+        "bbox_x1": -171.33287,
+        "bbox_y0": -14.06353,
+        "bbox_y1": -13.4322
+      }
+    },
+    {
+      "pk": 203,
+      "model": "base.region",
+      "fields": {
+        "rght": 412,
+        "code": "SMR",
+        "name": "San Marino",
+        "parent": 5,
+        "level": 2,
+        "lft": 411,
+        "tree_id": 90,
+        "bbox_x0": 12.40306,
+        "bbox_x1": 12.51651,
+        "bbox_y0": 43.893299,
+        "bbox_y1": 43.992168
+      }
+    },
+    {
+      "pk": 204,
+      "model": "base.region",
+      "fields": {
+        "rght": 119,
+        "code": "STP",
+        "name": "Sao Tome and Principe",
+        "parent": 13,
+        "level": 3,
+        "lft": 118,
+        "tree_id": 90,
+        "bbox_x0": 5.59955,
+        "bbox_x1": 7.46637,
+        "bbox_y0": -0.014,
+        "bbox_y1": 1.73378
+      }
+    },
+    {
+      "pk": 205,
+      "model": "base.region",
+      "fields": {
+        "rght": 456,
+        "code": "SAU",
+        "name": "Saudi Arabia",
+        "parent": 15,
+        "level": 2,
+        "lft": 455,
+        "tree_id": 90,
+        "bbox_x0": 34.508282,
+        "bbox_x1": 55.666672,
+        "bbox_y0": 16.261169,
+        "bbox_y1": 32.173481
+      }
+    },
+    {
+      "pk": 206,
+      "model": "base.region",
+      "fields": {
+        "rght": 121,
+        "code": "SEN",
+        "name": "Senegal",
+        "parent": 13,
+        "level": 3,
+        "lft": 120,
+        "tree_id": 90,
+        "bbox_x0": -17.535231,
+        "bbox_x1": -11.35588,
+        "bbox_y0": 12.30727,
+        "bbox_y1": 16.691629
+      }
+    },
+    {
+      "pk": 207,
+      "model": "base.region",
+      "fields": {
+        "rght": 414,
+        "code": "SRB",
+        "name": "Serbia",
+        "parent": 5,
+        "level": 2,
+        "lft": 413,
+        "tree_id": 90,
+        "bbox_x0": 18.814581,
+        "bbox_x1": 23.007,
+        "bbox_y0": 41.908611,
+        "bbox_y1": 46.191002
+      }
+    },
+    {
+      "pk": 208,
+      "model": "base.region",
+      "fields": {
+        "rght": 41,
+        "code": "SYC",
+        "name": "Seychelles",
+        "parent": 12,
+        "level": 3,
+        "lft": 40,
+        "tree_id": 90,
+        "bbox_x0": 46.199211,
+        "bbox_x1": 56.279499,
+        "bbox_y0": -10.21712,
+        "bbox_y1": -3.71151
+      }
+    },
+    {
+      "pk": 209,
+      "model": "base.region",
+      "fields": {
+        "rght": 123,
+        "code": "SLE",
+        "name": "Sierra Leone",
+        "parent": 13,
+        "level": 3,
+        "lft": 122,
+        "tree_id": 90,
+        "bbox_x0": -13.30763,
+        "bbox_x1": -10.28423,
+        "bbox_y0": 6.92868,
+        "bbox_y1": 10.00043
+      }
+    },
+    {
+      "pk": 210,
+      "model": "base.region",
+      "fields": {
+        "rght": 309,
+        "code": "SGP",
+        "name": "Singapore",
+        "parent": 7,
+        "level": 3,
+        "lft": 308,
+        "tree_id": 90,
+        "bbox_x0": 103.618248,
+        "bbox_x1": 104.40847,
+        "bbox_y0": 1.1158,
+        "bbox_y1": 1.47062
+      }
+    },
+    {
+      "pk": 211,
+      "model": "base.region",
+      "fields": {
+        "rght": 416,
+        "code": "SVK",
+        "name": "Slovakia",
+        "parent": 5,
+        "level": 2,
+        "lft": 415,
+        "tree_id": 90,
+        "bbox_x0": 16.833179,
+        "bbox_x1": 22.570299,
+        "bbox_y0": 47.728001,
+        "bbox_y1": 49.603001
+      }
+    },
+    {
+      "pk": 212,
+      "model": "base.region",
+      "fields": {
+        "rght": 418,
+        "code": "SVN",
+        "name": "Slovenia",
+        "parent": 5,
+        "level": 2,
+        "lft": 417,
+        "tree_id": 90,
+        "bbox_x0": 13.37551,
+        "bbox_x1": 16.59656,
+        "bbox_y0": 45.416,
+        "bbox_y1": 46.87788
+      }
+    },
+    {
+      "pk": 213,
+      "model": "base.region",
+      "fields": {
+        "rght": 504,
+        "code": "SLB",
+        "name": "Solomon Islands",
+        "parent": 256,
+        "level": 2,
+        "lft": 503,
+        "tree_id": 90,
+        "bbox_x0": 155.508667,
+        "bbox_x1": 170.200455,
+        "bbox_y0": -12.2919,
+        "bbox_y1": -5.16622
+      }
+    },
+    {
+      "pk": 214,
+      "model": "base.region",
+      "fields": {
+        "rght": 43,
+        "code": "SOM",
+        "name": "Somalia",
+        "parent": 12,
+        "level": 3,
+        "lft": 42,
+        "tree_id": 90,
+        "bbox_x0": 40.988628,
+        "bbox_x1": 51.413029,
+        "bbox_y0": -1.66205,
+        "bbox_y1": 11.9852
+      }
+    },
+    {
+      "pk": 215,
+      "model": "base.region",
+      "fields": {
+        "rght": 75,
+        "code": "ZAF",
+        "name": "South Africa",
+        "parent": 14,
+        "level": 3,
+        "lft": 74,
+        "tree_id": 90,
+        "bbox_x0": 16.46841,
+        "bbox_x1": 37.993172,
+        "bbox_y0": -46.990009,
+        "bbox_y1": -22.12472
+      }
+    },
+    {
+      "pk": 216,
+      "model": "base.region",
+      "fields": {
+        "rght": 420,
+        "code": "ESP",
+        "name": "Spain",
+        "parent": 5,
+        "level": 2,
+        "lft": 419,
+        "tree_id": 90,
+        "bbox_x0": -18.160789,
+        "bbox_x1": 4.32788,
+        "bbox_y0": 27.63546,
+        "bbox_y1": 43.789959
+      }
+    },
+    {
+      "pk": 217,
+      "model": "base.region",
+      "fields": {
+        "rght": 291,
+        "code": "LKA",
+        "name": "Sri Lanka",
+        "parent": 9,
+        "level": 3,
+        "lft": 290,
+        "tree_id": 90,
+        "bbox_x0": 79.516212,
+        "bbox_x1": 81.88121,
+        "bbox_y0": 5.9167,
+        "bbox_y1": 9.8312
+      }
+    },
+    {
+      "pk": 218,
+      "model": "base.region",
+      "fields": {
+        "rght": 59,
+        "code": "SDN",
+        "name": "Sudan",
+        "parent": 11,
+        "level": 3,
+        "lft": 58,
+        "tree_id": 90,
+        "bbox_x0": 21.83894,
+        "bbox_x1": 38.833801,
+        "bbox_y0": 3.48639,
+        "bbox_y1": 23.146891
+      }
+    },
+    {
+      "pk": 219,
+      "model": "base.region",
+      "fields": {
+        "rght": 237,
+        "code": "SUR",
+        "name": "Suriname",
+        "parent": 4,
+        "level": 3,
+        "lft": 236,
+        "tree_id": 90,
+        "bbox_x0": -58.086559,
+        "bbox_x1": -53.977489,
+        "bbox_y0": 1.83114,
+        "bbox_y1": 6.00454
+      }
+    },
+    {
+      "pk": 220,
+      "model": "base.region",
+      "fields": {
+        "rght": 422,
+        "code": "SJM",
+        "name": "Svalbard and Jan Mayen Islands",
+        "parent": 5,
+        "level": 2,
+        "lft": 421,
+        "tree_id": 90,
+        "bbox_x0": -9.07989,
+        "bbox_x1": 36.815269,
+        "bbox_y0": 70.82737,
+        "bbox_y1": 80.834061
+      }
+    },
+    {
+      "pk": 221,
+      "model": "base.region",
+      "fields": {
+        "rght": 77,
+        "code": "SWZ",
+        "name": "Swaziland",
+        "parent": 14,
+        "level": 3,
+        "lft": 76,
+        "tree_id": 90,
+        "bbox_x0": 30.7941,
+        "bbox_x1": 32.137272,
+        "bbox_y0": -27.317101,
+        "bbox_y1": -25.719641
+      }
+    },
+    {
+      "pk": 222,
+      "model": "base.region",
+      "fields": {
+        "rght": 424,
+        "code": "SWE",
+        "name": "Sweden",
+        "parent": 5,
+        "level": 2,
+        "lft": 423,
+        "tree_id": 90,
+        "bbox_x0": 10.9661,
+        "bbox_x1": 24.16634,
+        "bbox_y0": 55.33696,
+        "bbox_y1": 69.059937
+      }
+    },
+    {
+      "pk": 223,
+      "model": "base.region",
+      "fields": {
+        "rght": 426,
+        "code": "CHE",
+        "name": "Switzerland",
+        "parent": 5,
+        "level": 2,
+        "lft": 425,
+        "tree_id": 90,
+        "bbox_x0": 5.95587,
+        "bbox_x1": 10.49203,
+        "bbox_y0": 45.81802,
+        "bbox_y1": 47.80838
+      }
+    },
+    {
+      "pk": 224,
+      "model": "base.region",
+      "fields": {
+        "rght": 458,
+        "code": "SYR",
+        "name": "Syrian Arab Republic",
+        "parent": 15,
+        "level": 2,
+        "lft": 457,
+        "tree_id": 90,
+        "bbox_x0": 35.727001,
+        "bbox_x1": 42.384998,
+        "bbox_y0": 32.3106,
+        "bbox_y1": 37.319
+      }
+    },
+    {
+      "pk": 225,
+      "model": "base.region",
+      "fields": {
+        "rght": 255,
+        "code": "TJK",
+        "name": "Tajikistan",
+        "parent": 8,
+        "level": 3,
+        "lft": 254,
+        "tree_id": 90,
+        "bbox_x0": 67.387131,
+        "bbox_x1": 75.137222,
+        "bbox_y0": 36.674141,
+        "bbox_y1": 41.04224
+      }
+    },
+    {
+      "pk": 226,
+      "model": "base.region",
+      "fields": {
+        "rght": 311,
+        "code": "THA",
+        "name": "Thailand",
+        "parent": 7,
+        "level": 3,
+        "lft": 310,
+        "tree_id": 90,
+        "bbox_x0": 97.343964,
+        "bbox_x1": 105.636917,
+        "bbox_y0": 5.61257,
+        "bbox_y1": 20.464701
+      }
+    },
+    {
+      "pk": 227,
+      "model": "base.region",
+      "fields": {
+        "rght": 313,
+        "code": "TLS",
+        "name": "Timor-Leste",
+        "parent": 7,
+        "level": 3,
+        "lft": 312,
+        "tree_id": 90,
+        "bbox_x0": 124.075439,
+        "bbox_x1": 127.345337,
+        "bbox_y0": -9.51337,
+        "bbox_y1": -8.13741
+      }
+    },
+    {
+      "pk": 228,
+      "model": "base.region",
+      "fields": {
+        "rght": 125,
+        "code": "TGO",
+        "name": "Togo",
+        "parent": 13,
+        "level": 3,
+        "lft": 124,
+        "tree_id": 90,
+        "bbox_x0": -0.14731,
+        "bbox_x1": 1.80669,
+        "bbox_y0": 6.10441,
+        "bbox_y1": 11.13897
+      }
+    },
+    {
+      "pk": 229,
+      "model": "base.region",
+      "fields": {
+        "rght": 506,
+        "code": "TKL",
+        "name": "Tokelau",
+        "parent": 256,
+        "level": 2,
+        "lft": 505,
+        "tree_id": 90,
+        "bbox_x0": -172.517136,
+        "bbox_x1": -171.182083,
+        "bbox_y0": -9.43378,
+        "bbox_y1": -8.53288
+      }
+    },
+    {
+      "pk": 230,
+      "model": "base.region",
+      "fields": {
+        "rght": 508,
+        "code": "TON",
+        "name": "Tonga",
+        "parent": 256,
+        "level": 2,
+        "lft": 507,
+        "tree_id": 90,
+        "bbox_x0": -176.212646,
+        "bbox_x1": -173.702438,
+        "bbox_y0": -22.345711,
+        "bbox_y1": -15.55326
+      }
+    },
+    {
+      "pk": 231,
+      "model": "base.region",
+      "fields": {
+        "rght": 181,
+        "code": "TTO",
+        "name": "Trinidad and Tobago",
+        "parent": 255,
+        "level": 3,
+        "lft": 180,
+        "tree_id": 90,
+        "bbox_x0": -61.927391,
+        "bbox_x1": -60.49144,
+        "bbox_y0": 10.03648,
+        "bbox_y1": 11.36118
+      }
+    },
+    {
+      "pk": 232,
+      "model": "base.region",
+      "fields": {
+        "rght": 61,
+        "code": "TUN",
+        "name": "Tunisia",
+        "parent": 11,
+        "level": 3,
+        "lft": 60,
+        "tree_id": 90,
+        "bbox_x0": 7.52481,
+        "bbox_x1": 11.59827,
+        "bbox_y0": 30.240431,
+        "bbox_y1": 37.56712
+      }
+    },
+    {
+      "pk": 233,
+      "model": "base.region",
+      "fields": {
+        "rght": 428,
+        "code": "TUR",
+        "name": "Turkey",
+        "parent": 5,
+        "level": 2,
+        "lft": 427,
+        "tree_id": 90,
+        "bbox_x0": 25.664101,
+        "bbox_x1": 44.8297,
+        "bbox_y0": 35.809971,
+        "bbox_y1": 42.105499
+      }
+    },
+    {
+      "pk": 234,
+      "model": "base.region",
+      "fields": {
+        "rght": 257,
+        "code": "TKM",
+        "name": "Turkmenistan",
+        "parent": 8,
+        "level": 3,
+        "lft": 256,
+        "tree_id": 90,
+        "bbox_x0": 52.441429,
+        "bbox_x1": 66.684303,
+        "bbox_y0": 35.14109,
+        "bbox_y1": 42.795551
+      }
+    },
+    {
+      "pk": 235,
+      "model": "base.region",
+      "fields": {
+        "rght": 183,
+        "code": "TCA",
+        "name": "Turks and Caicos Islands",
+        "parent": 255,
+        "level": 3,
+        "lft": 182,
+        "tree_id": 90,
+        "bbox_x0": -72.483879,
+        "bbox_x1": -71.08033,
+        "bbox_y0": 21.170031,
+        "bbox_y1": 21.97361
+      }
+    },
+    {
+      "pk": 236,
+      "model": "base.region",
+      "fields": {
+        "rght": 510,
+        "code": "TUV",
+        "name": "Tuvalu",
+        "parent": 256,
+        "level": 2,
+        "lft": 509,
+        "tree_id": 90,
+        "bbox_x0": 176.06488,
+        "bbox_x1": 179.883789,
+        "bbox_y0": -10.75045,
+        "bbox_y1": -5.64198
+      }
+    },
+    {
+      "pk": 237,
+      "model": "base.region",
+      "fields": {
+        "rght": 45,
+        "code": "UGA",
+        "name": "Uganda",
+        "parent": 12,
+        "level": 3,
+        "lft": 44,
+        "tree_id": 90,
+        "bbox_x0": 29.573549,
+        "bbox_x1": 35.001251,
+        "bbox_y0": -1.47849,
+        "bbox_y1": 4.23403
+      }
+    },
+    {
+      "pk": 238,
+      "model": "base.region",
+      "fields": {
+        "rght": 430,
+        "code": "UKR",
+        "name": "Ukraine",
+        "parent": 5,
+        "level": 2,
+        "lft": 429,
+        "tree_id": 90,
+        "bbox_x0": 22.128811,
+        "bbox_x1": 40.218079,
+        "bbox_y0": 44.390411,
+        "bbox_y1": 52.375359
+      }
+    },
+    {
+      "pk": 239,
+      "model": "base.region",
+      "fields": {
+        "rght": 460,
+        "code": "ARE",
+        "name": "United Arab Emirates",
+        "parent": 15,
+        "level": 2,
+        "lft": 459,
+        "tree_id": 90,
+        "bbox_x0": 51.497978,
+        "bbox_x1": 56.38343,
+        "bbox_y0": 22.644409,
+        "bbox_y1": 26.28219
+      }
+    },
+    {
+      "pk": 240,
+      "model": "base.region",
+      "fields": {
+        "rght": 432,
+        "code": "GBR",
+        "name": "United Kingdom",
+        "parent": 5,
+        "level": 2,
+        "lft": 431,
+        "tree_id": 90,
+        "bbox_x0": -13.41393,
+        "bbox_x1": 1.76896,
+        "bbox_y0": 49.16209,
+        "bbox_y1": 60.854691
+      }
+    },
+    {
+      "pk": 241,
+      "model": "base.region",
+      "fields": {
+        "rght": 47,
+        "code": "TZA",
+        "name": "United Republic of Tanzania",
+        "parent": 12,
+        "level": 3,
+        "lft": 46,
+        "tree_id": 90,
+        "bbox_x0": 29.32716,
+        "bbox_x1": 40.443218,
+        "bbox_y0": -11.74569,
+        "bbox_y1": -0.99073
+      }
+    },
+    {
+      "pk": 242,
+      "model": "base.region",
+      "fields": {
+        "rght": 185,
+        "code": "VIR",
+        "name": "United States Virgin Islands",
+        "parent": 255,
+        "level": 3,
+        "lft": 184,
+        "tree_id": 90,
+        "bbox_x0": -65.086281,
+        "bbox_x1": -64.56517,
+        "bbox_y0": 17.681721,
+        "bbox_y1": 18.458139
+      }
+    },
+    {
+      "pk": 243,
+      "model": "base.region",
+      "fields": {
+        "rght": 211,
+        "code": "USA",
+        "name": "United States of America",
+        "parent": 2,
+        "level": 3,
+        "lft": 210,
+        "tree_id": 90,
+        "bbox_x0": -179.150558,
+        "bbox_x1": -66.940643,
+        "bbox_y0": 18.91172,
+        "bbox_y1": 71.441048
+      }
+    },
+    {
+      "pk": 244,
+      "model": "base.region",
+      "fields": {
+        "rght": 239,
+        "code": "URY",
+        "name": "Uruguay",
+        "parent": 4,
+        "level": 3,
+        "lft": 238,
+        "tree_id": 90,
+        "bbox_x0": -58.442719,
+        "bbox_x1": -53.073929,
+        "bbox_y0": -35.047939,
+        "bbox_y1": -30.08222
+      }
+    },
+    {
+      "pk": 245,
+      "model": "base.region",
+      "fields": {
+        "rght": 259,
+        "code": "UZB",
+        "name": "Uzbekistan",
+        "parent": 8,
+        "level": 3,
+        "lft": 258,
+        "tree_id": 90,
+        "bbox_x0": 55.996632,
+        "bbox_x1": 73.132271,
+        "bbox_y0": 37.18433,
+        "bbox_y1": 45.60519
+      }
+    },
+    {
+      "pk": 246,
+      "model": "base.region",
+      "fields": {
+        "rght": 512,
+        "code": "VUT",
+        "name": "Vanuatu",
+        "parent": 256,
+        "level": 2,
+        "lft": 511,
+        "tree_id": 90,
+        "bbox_x0": 166.524994,
+        "bbox_x1": 170.234802,
+        "bbox_y0": -20.25045,
+        "bbox_y1": -13.07345
+      }
+    },
+    {
+      "pk": 247,
+      "model": "base.region",
+      "fields": {
+        "rght": 241,
+        "code": "VEN",
+        "name": "Venezuela (Bolivarian Republic of)",
+        "parent": 4,
+        "level": 3,
+        "lft": 240,
+        "tree_id": 90,
+        "bbox_x0": -73.374313,
+        "bbox_x1": -59.803768,
+        "bbox_y0": 0.74368,
+        "bbox_y1": 12.2019
+      }
+    },
+    {
+      "pk": 248,
+      "model": "base.region",
+      "fields": {
+        "rght": 315,
+        "code": "VNM",
+        "name": "Viet Nam",
+        "parent": 7,
+        "level": 3,
+        "lft": 314,
+        "tree_id": 90,
+        "bbox_x0": 102.144592,
+        "bbox_x1": 116.521233,
+        "bbox_y0": 7.3116,
+        "bbox_y1": 23.39274
+      }
+    },
+    {
+      "pk": 249,
+      "model": "base.region",
+      "fields": {
+        "rght": 514,
+        "code": "WLF",
+        "name": "Wallis and Futuna Islands",
+        "parent": 256,
+        "level": 2,
+        "lft": 513,
+        "tree_id": 90,
+        "bbox_x0": -178.206787,
+        "bbox_x1": -176.08287,
+        "bbox_y0": -14.38779,
+        "bbox_y1": -13.17343
+      }
+    },
+    {
+      "pk": 250,
+      "model": "base.region",
+      "fields": {
+        "rght": 63,
+        "code": "ESH",
+        "name": "Western Sahara",
+        "parent": 11,
+        "level": 3,
+        "lft": 62,
+        "tree_id": 90,
+        "bbox_x0": -17.10317,
+        "bbox_x1": -8.66942,
+        "bbox_y0": 20.774151,
+        "bbox_y1": 28.219179
+      }
+    },
+    {
+      "pk": 251,
+      "model": "base.region",
+      "fields": {
+        "rght": 462,
+        "code": "YEM",
+        "name": "Yemen",
+        "parent": 15,
+        "level": 2,
+        "lft": 461,
+        "tree_id": 90,
+        "bbox_x0": 41.809608,
+        "bbox_x1": 54.535992,
+        "bbox_y0": 12.10717,
+        "bbox_y1": 19.00276
+      }
+    },
+    {
+      "pk": 252,
+      "model": "base.region",
+      "fields": {
+        "rght": 79,
+        "code": "ZMB",
+        "name": "Zambia",
+        "parent": 14,
+        "level": 3,
+        "lft": 78,
+        "tree_id": 90,
+        "bbox_x0": 21.99938,
+        "bbox_x1": 33.705711,
+        "bbox_y0": -18.07947,
+        "bbox_y1": -8.22436
+      }
+    },
+    {
+      "pk": 253,
+      "model": "base.region",
+      "fields": {
+        "rght": 81,
+        "code": "ZWE",
+        "name": "Zimbabwe",
+        "parent": 14,
+        "level": 3,
+        "lft": 80,
+        "tree_id": 90,
+        "bbox_x0": 25.23702,
+        "bbox_x1": 33.056301,
+        "bbox_y0": -22.41773,
+        "bbox_y1": -15.60883
+      }
+    },
+    {
+      "pk": 254,
+      "model": "base.region",
+      "fields": {
+        "rght": 243,
+        "code": "AME",
+        "name": "Americas",
+        "parent": null,
+        "level": 1,
+        "lft": 128,
+        "tree_id": 90,
+        "bbox_x0": -84.114449,
+        "bbox_x1": -84.097572,
+        "bbox_y0": 9.9313,
+        "bbox_y1": 9.94792
+      }
+    },
+    {
+      "pk": 255,
+      "model": "base.region",
+      "fields": {
+        "rght": 186,
+        "code": "CRB",
+        "name": "Caribbean",
+        "parent": 254,
+        "level": 2,
+        "lft": 129,
+        "tree_id": 90,
+        "bbox_x0": -85.260178,
+        "bbox_x1": -59.286541,
+        "bbox_y0": 10.18548,
+        "bbox_y1": 27.454559
+      }
+    },
+    {
+      "pk": 256,
+      "model": "base.region",
+      "fields": {
+        "rght": 515,
+        "code": "PAC",
+        "name": "Pacific",
+        "parent": null,
+        "level": 1,
+        "lft": 464,
+        "tree_id": 90,
+        "bbox_x0": 139.572356,
+        "bbox_x1": -74.531208,
+        "bbox_y0": -56.267241,
+        "bbox_y1": 62.0215969
+      }
+    },
+    {
+      "pk": 257,
+      "model": "base.region",
+      "fields": {
+        "rght": 12,
+        "code": "CFR",
+        "name": "Central Africa",
+        "parent": 10,
+        "level": 2,
+        "lft": 3,
+        "tree_id": 90,
+        "bbox_x0": -25.35874,
+        "bbox_x1": 63.525379,
+        "bbox_y0": -46.900452,
+        "bbox_y1": 37.56712
+      }
+    },
+    {
+      "pk": 258,
+      "model": "base.region",
+      "fields": {
+        "rght": 276,
+        "code": "EAS",
+        "name": "East Asia",
+        "parent": 6,
+        "level": 2,
+        "lft": 261,
+        "tree_id": 90,
+        "bbox_x0": 19.6381,
+        "bbox_x1": 180,
+        "bbox_y0": -12.56111,
+        "bbox_y1": 82.50045
+      }
+    },
+    {
+      "pk": 259,
+      "model": "base.region",
+      "fields": {
+        "rght": 59,
+        "code": "SSD",
+        "name": "South Sudan",
+        "parent": 11,
+        "level": 3,
+        "lft": 58,
+        "tree_id": 90,
+        "bbox_x0": 24.15192,
+        "bbox_x1": 35.947689,
+        "bbox_y0": 3.48639,
+        "bbox_y1": 12.21558
+      }
+    }
+]

--- a/fixtures/sample_admin.json
+++ b/fixtures/sample_admin.json
@@ -1,0 +1,18 @@
+[{
+	"fields": {
+		"date_joined": "2011-06-09 15:15:27",
+		"email": "ad@m.in",
+		"first_name": "",
+		"groups": [],
+		"is_active": true,
+		"is_staff": true,
+		"is_superuser": true,
+		"last_login": "2011-06-09 15:45:34",
+		"last_name": "",
+		"password": "pbkdf2_sha256$30000$rjuGt0Obn8on$cxF75frIOSaitNklLZ0IJ/VonUW0fwEFVF96o0M+lGc=",
+		"user_permissions": [],
+		"username": "admin"
+	},
+	"model": "people.Profile",
+	"pk": 1000
+}]

--- a/igb/__init__.py
+++ b/igb/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+
+__version__ = (2, 10, 0, 'rc', 4)
+
+
+default_app_config = "igb.apps.AppConfig"
+
+
+def get_version():
+    import igb.version
+    return igb.version.get_version(__version__)

--- a/igb/apps.py
+++ b/igb/apps.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+from django.apps import AppConfig as BaseAppConfig
+
+
+def run_setup_hooks(*args, **kwargs):
+    from django.conf import settings
+    from .celeryapp import app as celeryapp
+    if celeryapp not in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS += (celeryapp, )
+
+
+class AppConfig(BaseAppConfig):
+
+    name = "igb"
+    label = "igb"
+
+    def ready(self):
+        super(AppConfig, self).ready()
+        run_setup_hooks()
+

--- a/igb/celeryapp.py
+++ b/igb/celeryapp.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from __future__ import absolute_import
+
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'igb.settings')
+
+app = Celery('igb')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings', namespace="CELERY")
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print("Request: {!r}".format(self.request))

--- a/igb/local_settings.py.sample
+++ b/igb/local_settings.py.sample
@@ -1,0 +1,549 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+""" There are 3 ways to override GeoNode settings:
+   1. Using environment variables, if your changes to GeoNode are minimal.
+   2. Creating a downstream project, if you are doing a lot of customization.
+   3. Override settings in a local_settings.py file, legacy.
+"""
+
+import ast
+import os
+from urlparse import urlparse, urlunparse
+from geonode.settings import *
+
+# Require users to authenticate before using Geonode
+LOCKDOWN_GEONODE = strtobool(os.getenv('LOCKDOWN_GEONODE', 'False'))
+
+# Require users to authenticate before using Geonode
+if LOCKDOWN_GEONODE:
+    MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + \
+        ('geonode.security.middleware.LoginRequiredMiddleware',)
+
+# Add additional paths (as regular expressions) that don't require
+# authentication.
+# - authorized exempt urls needed for oauth when GeoNode is set to lockdown
+FORCE_SCRIPT_NAME = os.getenv('FORCE_SCRIPT_NAME', '')
+AUTH_EXEMPT_URLS = (
+    r'^%s/?$' % FORCE_SCRIPT_NAME,
+    '%s/o/*' % FORCE_SCRIPT_NAME,
+    '%s/gs/*' % FORCE_SCRIPT_NAME,
+    '%s/account/*' % FORCE_SCRIPT_NAME,
+    '%s/static/*' % FORCE_SCRIPT_NAME,
+    '%s/api/o/*' % FORCE_SCRIPT_NAME,
+    '%s/api/roles' % FORCE_SCRIPT_NAME,
+    '%s/api/adminRole' % FORCE_SCRIPT_NAME,
+    '%s/api/users' % FORCE_SCRIPT_NAME,
+    '%s/api/layers' % FORCE_SCRIPT_NAME,
+)
+
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+MEDIA_ROOT = os.getenv('MEDIA_ROOT', os.path.join(PROJECT_ROOT, "uploaded"))
+
+STATIC_ROOT = os.getenv('STATIC_ROOT',
+                        os.path.join(PROJECT_ROOT, "static_root")
+                        )
+
+# SECRET_KEY = '************************'
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = os.getenv('SECRET_KEY', "5-u486tl3^+o&9-hd1(1o_2+47h+hk8ughqi6i+0wsu#+_-eq6")
+
+# per-deployment settings should go here
+SITE_HOST_NAME = os.getenv('SITE_HOST_NAME', 'localhost')
+SITE_HOST_PORT = os.getenv('SITE_HOST_PORT', None)
+_default_siteurl = "http://%s:%s/" % (SITE_HOST_NAME, SITE_HOST_PORT) if SITE_HOST_PORT else "http://%s/" % SITE_HOST_NAME
+SITEURL = os.getenv('SITEURL', _default_siteurl)
+
+# we need hostname for deployed
+_surl = urlparse(SITEURL)
+HOSTNAME = _surl.hostname
+
+# add trailing slash to site url. geoserver url will be relative to this
+if not SITEURL.endswith('/'):
+    SITEURL = '{}/'.format(SITEURL)
+
+try:
+    # try to parse python notation, default in dockerized env
+    ALLOWED_HOSTS = ast.literal_eval(os.getenv('ALLOWED_HOSTS'))
+except ValueError:
+    # fallback to regular list of values separated with misc chars
+    ALLOWED_HOSTS = [HOSTNAME, 'localhost', 'django', 'geonode'] if os.getenv('ALLOWED_HOSTS') is None \
+        else re.split(r' *[,|:|;] *', os.getenv('ALLOWED_HOSTS'))
+
+TIME_ZONE = 'UTC'
+
+# Login and logout urls override
+LOGIN_URL = os.getenv('LOGIN_URL', '{}account/login/'.format(SITEURL))
+LOGOUT_URL = os.getenv('LOGOUT_URL', '{}account/logout/'.format(SITEURL))
+
+ACCOUNT_LOGIN_REDIRECT_URL = os.getenv('LOGIN_REDIRECT_URL', SITEURL)
+ACCOUNT_LOGOUT_REDIRECT_URL =  os.getenv('LOGOUT_REDIRECT_URL', SITEURL)
+
+# Backend
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'geonode',
+        'USER': 'geonode',
+        'PASSWORD': 'geonode',
+        'HOST': 'localhost',
+        'PORT': '5432',
+        'CONN_TOUT': 900,
+    },
+    # vector datastore for uploads
+    'datastore': {
+        'ENGINE': 'django.contrib.gis.db.backends.postgis',
+        # 'ENGINE': '', # Empty ENGINE name disables
+        'NAME': 'geonode_data',
+        'USER': 'geonode',
+        'PASSWORD': 'geonode',
+        'HOST': 'localhost',
+        'PORT': '5432',
+        'CONN_TOUT': 900,
+    }
+}
+
+GEOSERVER_LOCATION = os.getenv(
+    'GEOSERVER_LOCATION', 'http://localhost:8080/geoserver/'
+)
+
+GEOSERVER_PUBLIC_HOST = os.getenv(
+    'GEOSERVER_PUBLIC_HOST', SITE_HOST_NAME
+)
+
+GEOSERVER_PUBLIC_PORT = os.getenv(
+    'GEOSERVER_PUBLIC_PORT', SITE_HOST_PORT
+)
+
+_default_public_location = 'http://{}:{}/gs/'.format(GEOSERVER_PUBLIC_HOST, GEOSERVER_PUBLIC_PORT) if GEOSERVER_PUBLIC_PORT else 'http://{}/gs/'.format(GEOSERVER_PUBLIC_HOST)
+
+GEOSERVER_WEB_UI_LOCATION = os.getenv(
+    'GEOSERVER_WEB_UI_LOCATION', GEOSERVER_LOCATION
+)
+
+GEOSERVER_PUBLIC_LOCATION = os.getenv(
+    'GEOSERVER_PUBLIC_LOCATION', _default_public_location
+)
+
+OGC_SERVER_DEFAULT_USER = os.getenv(
+    'GEOSERVER_ADMIN_USER', 'admin'
+)
+
+OGC_SERVER_DEFAULT_PASSWORD = os.getenv(
+    'GEOSERVER_ADMIN_PASSWORD', 'geoserver'
+)
+
+# OGC (WMS/WFS/WCS) Server Settings
+OGC_SERVER = {
+    'default': {
+        'BACKEND': 'geonode.geoserver',
+        'LOCATION': GEOSERVER_LOCATION,
+        'WEB_UI_LOCATION': GEOSERVER_WEB_UI_LOCATION,
+        'LOGIN_ENDPOINT': 'j_spring_oauth2_geonode_login',
+        'LOGOUT_ENDPOINT': 'j_spring_oauth2_geonode_logout',
+        # PUBLIC_LOCATION needs to be kept like this because in dev mode
+        # the proxy won't work and the integration tests will fail
+        # the entire block has to be overridden in the local_settings
+        'PUBLIC_LOCATION': GEOSERVER_PUBLIC_LOCATION,
+        'USER': OGC_SERVER_DEFAULT_USER,
+        'PASSWORD': OGC_SERVER_DEFAULT_PASSWORD,
+        'MAPFISH_PRINT_ENABLED': True,
+        'PRINT_NG_ENABLED': True,
+        'GEONODE_SECURITY_ENABLED': True,
+        'GEOFENCE_SECURITY_ENABLED': True,
+        'WMST_ENABLED': False,
+        'BACKEND_WRITE_ENABLED': True,
+        'WPS_ENABLED': False,
+        'LOG_FILE': '%s/geoserver/data/logs/geoserver.log' % os.path.abspath(os.path.join(PROJECT_ROOT, os.pardir)),
+        # Set to dictionary identifier of database containing spatial data in DATABASES dictionary to enable
+        'DATASTORE': 'datastore',
+        'TIMEOUT': 60  # number of seconds to allow for HTTP requests
+    }
+}
+
+# WARNING: Map Editing is affected by this. GeoExt Configuration is cached for 5 minutes
+# CACHES = {
+#     'default': {
+#         'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+#         'LOCATION': '/var/tmp/django_cache',
+#     }
+# }
+
+# If you want to enable Mosaics use the following configuration
+UPLOADER = {
+    # 'BACKEND': 'geonode.rest',
+    'BACKEND': 'geonode.importer',
+    'OPTIONS': {
+        'TIME_ENABLED': True,
+        'MOSAIC_ENABLED': False,
+    },
+    'SUPPORTED_CRS': [
+        'EPSG:4326',
+        'EPSG:3785',
+        'EPSG:3857',
+        'EPSG:32647',
+        'EPSG:32736'
+    ],
+    'SUPPORTED_EXT': [
+        '.shp',
+        '.csv',
+        '.kml',
+        '.kmz',
+        '.json',
+        '.geojson',
+        '.tif',
+        '.tiff',
+        '.geotiff',
+        '.gml',
+        '.xml'
+    ]
+}
+
+# CSW settings
+CATALOGUE = {
+    'default': {
+        # The underlying CSW implementation
+        # default is pycsw in local mode (tied directly to GeoNode Django DB)
+        'ENGINE': 'geonode.catalogue.backends.pycsw_local',
+        # pycsw in non-local mode
+        # 'ENGINE': 'geonode.catalogue.backends.pycsw_http',
+        # GeoNetwork opensource
+        # 'ENGINE': 'geonode.catalogue.backends.geonetwork',
+        # deegree and others
+        # 'ENGINE': 'geonode.catalogue.backends.generic',
+
+        # The FULLY QUALIFIED base url to the CSW instance for this GeoNode
+        'URL': urljoin(SITEURL, '/catalogue/csw'),
+        # 'URL': 'http://localhost:8080/geonetwork/srv/en/csw',
+        # 'URL': 'http://localhost:8080/deegree-csw-demo-3.0.4/services',
+
+        # login credentials (for GeoNetwork)
+        # 'USER': 'admin',
+        # 'PASSWORD': 'admin',
+
+        # 'ALTERNATES_ONLY': True,
+    }
+}
+
+# pycsw settings
+PYCSW = {
+    # pycsw configuration
+    'CONFIGURATION': {
+        # uncomment / adjust to override server config system defaults
+        # 'server': {
+        #    'maxrecords': '10',
+        #    'pretty_print': 'true',
+        #    'federatedcatalogues': 'http://catalog.data.gov/csw'
+        # },
+        'server': {
+            'home': '.',
+            'url': CATALOGUE['default']['URL'],
+            'encoding': 'UTF-8',
+            'language': LANGUAGE_CODE,
+            'maxrecords': '20',
+            'pretty_print': 'true',
+            # 'domainquerytype': 'range',
+            'domaincounts': 'true',
+            'profiles': 'apiso,ebrim',
+        },
+        'manager': {
+            # authentication/authorization is handled by Django
+            'transactions': 'false',
+            'allowed_ips': '*',
+            # 'csw_harvest_pagesize': '10',
+        },
+        'metadata:main': {
+            'identification_title': 'GeoNode Catalogue',
+            'identification_abstract': 'GeoNode is an open source platform' \
+            ' that facilitates the creation, sharing, and collaborative use' \
+            ' of geospatial data',
+            'identification_keywords': 'sdi, catalogue, discovery, metadata,' \
+            ' GeoNode',
+            'identification_keywords_type': 'theme',
+            'identification_fees': 'None',
+            'identification_accessconstraints': 'None',
+            'provider_name': 'Organization Name',
+            'provider_url': SITEURL,
+            'contact_name': 'Lastname, Firstname',
+            'contact_position': 'Position Title',
+            'contact_address': 'Mailing Address',
+            'contact_city': 'City',
+            'contact_stateorprovince': 'Administrative Area',
+            'contact_postalcode': 'Zip or Postal Code',
+            'contact_country': 'Country',
+            'contact_phone': '+xx-xxx-xxx-xxxx',
+            'contact_fax': '+xx-xxx-xxx-xxxx',
+            'contact_email': 'Email Address',
+            'contact_url': 'Contact URL',
+            'contact_hours': 'Hours of Service',
+            'contact_instructions': 'During hours of service. Off on ' \
+            'weekends.',
+            'contact_role': 'pointOfContact',
+        },
+        'metadata:inspire': {
+            'enabled': 'true',
+            'languages_supported': 'eng,gre',
+            'default_language': 'eng',
+            'date': 'YYYY-MM-DD',
+            'gemet_keywords': 'Utility and governmental services',
+            'conformity_service': 'notEvaluated',
+            'contact_name': 'Organization Name',
+            'contact_email': 'Email Address',
+            'temp_extent': 'YYYY-MM-DD/YYYY-MM-DD',
+        }
+    }
+}
+
+MAPBOX_ACCESS_TOKEN = os.environ.get('MAPBOX_ACCESS_TOKEN', None)
+BING_API_KEY = os.environ.get('BING_API_KEY', None)
+GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY', None)
+
+MAP_BASELAYERS = [{
+    "source": {"ptype": "gxp_olsource"},
+    "type": "OpenLayers.Layer",
+    "args": ["No background"],
+    "name": "background",
+    "visibility": False,
+    "fixed": True,
+    "group":"background"
+},
+    # {
+    #     "source": {"ptype": "gxp_olsource"},
+    #     "type": "OpenLayers.Layer.XYZ",
+    #     "title": "TEST TILE",
+    #     "args": ["TEST_TILE", "http://test_tiles/tiles/${z}/${x}/${y}.png"],
+    #     "name": "background",
+    #     "attribution": "&copy; TEST TILE",
+    #     "visibility": False,
+    #     "fixed": True,
+    #     "group":"background"
+    # },
+    {
+    "source": {"ptype": "gxp_osmsource"},
+    "type": "OpenLayers.Layer.OSM",
+    "name": "mapnik",
+    "visibility": True,
+    "fixed": True,
+    "group": "background"
+}]
+
+if 'geonode.geoserver' in INSTALLED_APPS:
+    LOCAL_GEOSERVER = {
+        "source": {
+            "ptype": "gxp_wmscsource",
+            "url": OGC_SERVER['default']['PUBLIC_LOCATION'] + "wms",
+            "restUrl": "/gs/rest"
+        }
+    }
+    baselayers = MAP_BASELAYERS
+    MAP_BASELAYERS = [LOCAL_GEOSERVER]
+    MAP_BASELAYERS.extend(baselayers)
+
+# To enable the REACT based Client enable those
+# INSTALLED_APPS += ('geonode-client', )
+# GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY = 'react'  # DEPRECATED use HOOKSET instead
+# GEONODE_CLIENT_HOOKSET = "geonode.client.hooksets.ReactHookSet"
+
+# To enable the Leaflet based Client enable those
+# GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY = 'leaflet'  # DEPRECATED use HOOKSET instead
+# GEONODE_CLIENT_HOOKSET = "geonode.client.hooksets.LeafletHookSet"
+
+# CORS_ORIGIN_WHITELIST = (
+#     HOSTNAME
+# )
+
+# To enable the MapStore2 based Client enable those
+# if 'geonode_mapstore_client' not in INSTALLED_APPS:
+#     INSTALLED_APPS += (
+#         'mapstore2_adapter',
+#         'geonode_mapstore_client',)
+# GEONODE_CLIENT_LAYER_PREVIEW_LIBRARY = 'mapstore'  # DEPRECATED use HOOKSET instead
+# GEONODE_CLIENT_HOOKSET = "geonode_mapstore_client.hooksets.MapStoreHookSet"
+# MAPSTORE_DEBUG = False
+
+def get_geonode_catalogue_service():
+    if PYCSW:
+        pycsw_config = PYCSW["CONFIGURATION"]
+        if pycsw_config:
+                pycsw_catalogue = {
+                    ("%s" % pycsw_config['metadata:main']['identification_title']): {
+                        "url": CATALOGUE['default']['URL'],
+                        "type": "csw",
+                        "title": pycsw_config['metadata:main']['identification_title'],
+                        "autoload": True
+                     }
+                }
+                return pycsw_catalogue
+    return None
+
+GEONODE_CATALOGUE_SERVICE = get_geonode_catalogue_service()
+
+MAPSTORE_CATALOGUE_SERVICES = {
+    "Demo WMS Service": {
+        "url": "https://demo.geo-solutions.it/geoserver/wms",
+        "type": "wms",
+        "title": "Demo WMS Service",
+        "autoload": False
+     },
+    "Demo WMTS Service": {
+        "url": "https://demo.geo-solutions.it/geoserver/gwc/service/wmts",
+        "type": "wmts",
+        "title": "Demo WMTS Service",
+        "autoload": False
+    }
+}
+
+MAPSTORE_CATALOGUE_SELECTED_SERVICE = "Demo WMS Service"
+
+if GEONODE_CATALOGUE_SERVICE:
+    MAPSTORE_CATALOGUE_SERVICES[GEONODE_CATALOGUE_SERVICE.keys()[0]] = GEONODE_CATALOGUE_SERVICE[GEONODE_CATALOGUE_SERVICE.keys()[0]]
+    MAPSTORE_CATALOGUE_SELECTED_SERVICE = GEONODE_CATALOGUE_SERVICE.keys()[0]
+
+    DEFAULT_MS2_BACKGROUNDS = [
+        {
+            "type": "osm",
+            "title": "Open Street Map",
+            "name": "mapnik",
+            "source": "osm",
+            "group": "background",
+            "visibility": True
+        }, {
+            "type": "tileprovider",
+            "title": "OpenTopoMap",
+            "provider": "OpenTopoMap",
+            "name": "OpenTopoMap",
+            "source": "OpenTopoMap",
+            "group": "background",
+            "visibility": False
+        }, {
+            "type": "wms",
+            "title": "Sentinel-2 cloudless - https://s2maps.eu",
+            "format": "image/png8",
+            "id": "s2cloudless",
+            "name": "s2cloudless:s2cloudless",
+            "url": "https://maps.geo-solutions.it/geoserver/wms",
+            "group": "background",
+            "thumbURL": "%sstatic/mapstorestyle/img/s2cloudless-s2cloudless.png" % SITEURL,
+            "visibility": False
+       }, {
+            "source": "ol",
+            "group": "background",
+            "id": "none",
+            "name": "empty",
+            "title": "Empty Background",
+            "type": "empty",
+            "visibility": False,
+            "args": ["Empty Background", {"visibility": False}]
+        }
+    ]
+
+MAPSTORE_BASELAYERS = DEFAULT_MS2_BACKGROUNDS
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d '
+                      '%(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(message)s',
+        },
+    },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple'
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler',
+        }
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"], "level": "ERROR", },
+        "geonode": {
+            "handlers": ["console"], "level": "INFO", },
+        "geonode.qgis_server": {
+            "handlers": ["console"], "level": "ERROR", },
+        "gsconfig.catalog": {
+            "handlers": ["console"], "level": "ERROR", },
+        "owslib": {
+            "handlers": ["console"], "level": "ERROR", },
+        "pycsw": {
+            "handlers": ["console"], "level": "INFO", },
+        "celery": {
+            'handlers': ["console"], 'level': 'ERROR', },
+    },
+}
+
+# Additional settings
+CORS_ORIGIN_ALLOW_ALL = True
+
+GEOIP_PATH = "/usr/local/share/GeoIP"
+
+# add following lines to your local settings to enable monitoring
+MONITORING_ENABLED = True
+
+if MONITORING_ENABLED:
+    if 'geonode.contrib.monitoring' not in INSTALLED_APPS:
+        INSTALLED_APPS += ('geonode.contrib.monitoring',)
+    if 'geonode.contrib.monitoring.middleware.MonitoringMiddleware' not in MIDDLEWARE_CLASSES:
+        MIDDLEWARE_CLASSES += \
+            ('geonode.contrib.monitoring.middleware.MonitoringMiddleware',)
+    MONITORING_CONFIG = None
+    MONITORING_HOST_NAME = os.getenv("MONITORING_HOST_NAME", HOSTNAME)
+    MONITORING_SERVICE_NAME = 'geonode'
+
+
+# Documents Thumbnails
+UNOCONV_ENABLE = True
+
+if UNOCONV_ENABLE:
+    UNOCONV_EXECUTABLE = os.getenv('UNOCONV_EXECUTABLE', '/usr/bin/unoconv')
+    UNOCONV_TIMEOUT = os.getenv('UNOCONV_TIMEOUT', 30)  # seconds
+
+# Advanced Security Workflow Settings
+DELAYED_SECURITY_SIGNALS = False
+ACCOUNT_OPEN_SIGNUP = True
+ACCOUNT_APPROVAL_REQUIRED = True
+CLIENT_RESULTS_LIMIT = 20
+API_LIMIT_PER_PAGE = 1000
+FREETEXT_KEYWORDS_READONLY = False
+RESOURCE_PUBLISHING = False
+ADMIN_MODERATE_UPLOADS = False
+GROUP_PRIVATE_RESOURCES = False
+GROUP_MANDATORY_RESOURCES = False
+MODIFY_TOPICCATEGORY = True
+USER_MESSAGES_ALLOW_MULTIPLE_RECIPIENTS = True
+DISPLAY_WMS_LINKS = True
+
+# For more information on available settings please consult the Django docs at
+# https://docs.djangoproject.com/en/dev/ref/settings

--- a/igb/settings.py
+++ b/igb/settings.py
@@ -18,44 +18,48 @@
 #
 #########################################################################
 
-# Django settings for the GeoNode project.
-import ast
 import os
-from urlparse import urlparse, urlunparse
 
-# Load more settings from a file called local_settings.py if it exists
-try:
-    from igb.local_settings import *
-#    from geonode.local_settings import *
-except ImportError:
-    from geonode.settings import *
+import environ
+from pathlib2 import Path
 
-#
-# General Django development settings
-#
-PROJECT_NAME = 'igb'
+from geonode.settings import *
 
-# add trailing slash to site url. geoserver url will be relative to this
-if not SITEURL.endswith('/'):
-    SITEURL = '{}/'.format(SITEURL)
-
-SITENAME = os.getenv("SITENAME", 'igb')
+env = environ.Env(
+    DEBUG=(bool, False)
+)
 
 # Defines the directory that contains the settings file as the LOCAL_ROOT
 # It is used for relative settings elsewhere.
-LOCAL_ROOT = os.path.abspath(os.path.dirname(__file__))
+LOCAL_ROOT = str(Path(__file__).resolve().parent)
+
+PROJECT_NAME = 'igb'
+
+DEBUG = env("DEBUG")
+
+TEMPLATE_DEBUG = DEBUG
+
+DATABASES = {
+    "default": env.db_url("DJANGO_DATABASE_URL"),
+    "datastore": env.db_url("GEONODE_DB_URL"),
+}
+
+ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS")
+
+SITEURL = env("DJANGO_SITEURL")
+
+SITENAME = env("DJANGO_SITENAME", default='igb')
 
 WSGI_APPLICATION = "{}.wsgi.application".format(PROJECT_NAME)
 
-# Language code for this installation. All choices can be found here:
-# http://www.i18nguy.com/unicode/language-identifiers.html
-LANGUAGE_CODE = os.getenv('LANGUAGE_CODE', "en")
+LANGUAGE_CODE = env("LANGUAGE_CODE", default="en")
 
 if PROJECT_NAME not in INSTALLED_APPS:
     INSTALLED_APPS += (PROJECT_NAME,)
 
 # Location of url mappings
-ROOT_URLCONF = os.getenv('ROOT_URLCONF', '{}.urls'.format(PROJECT_NAME))
+# ROOT_URLCONF = os.getenv('ROOT_URLCONF', '{}.urls'.format(PROJECT_NAME))
+ROOT_URLCONF = '{}.urls'.format(PROJECT_NAME)
 
 # Additional directories which hold static files
 STATICFILES_DIRS.append(
@@ -68,13 +72,19 @@ LOCALE_PATHS = (
     ) + LOCALE_PATHS
 
 TEMPLATES[0]['DIRS'].insert(0, os.path.join(LOCAL_ROOT, "templates"))
-loaders = TEMPLATES[0]['OPTIONS'].get('loaders') or ['django.template.loaders.filesystem.Loader','django.template.loaders.app_directories.Loader']
+loaders = (
+    TEMPLATES[0]['OPTIONS'].get('loaders') or
+    [
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader'
+    ]
+)
 # loaders.insert(0, 'apptemplates.Loader')
 TEMPLATES[0]['OPTIONS']['loaders'] = loaders
 TEMPLATES[0].pop('APP_DIRS', None)
 
-UNOCONV_ENABLE = strtobool(os.getenv('UNOCONV_ENABLE', 'True'))
+UNOCONV_ENABLE = env("UNOCONV_ENABLE", cast=bool, default=True)
 
 if UNOCONV_ENABLE:
-    UNOCONV_EXECUTABLE = os.getenv('UNOCONV_EXECUTABLE', '/usr/bin/unoconv')
-    UNOCONV_TIMEOUT = os.getenv('UNOCONV_TIMEOUT', 30)  # seconds
+    UNOCONV_EXECUTABLE = env("UNOCONV_EXECUTABLE", default="/usr/bin/unoconv")
+    UNOCONV_TIMEOUT = env("UNOCONV_TIMEOUT", cast=int, default=30)  # seconds

--- a/igb/settings.py
+++ b/igb/settings.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+# Django settings for the GeoNode project.
+import ast
+import os
+from urlparse import urlparse, urlunparse
+
+# Load more settings from a file called local_settings.py if it exists
+try:
+    from igb.local_settings import *
+#    from geonode.local_settings import *
+except ImportError:
+    from geonode.settings import *
+
+#
+# General Django development settings
+#
+PROJECT_NAME = 'igb'
+
+# add trailing slash to site url. geoserver url will be relative to this
+if not SITEURL.endswith('/'):
+    SITEURL = '{}/'.format(SITEURL)
+
+SITENAME = os.getenv("SITENAME", 'igb')
+
+# Defines the directory that contains the settings file as the LOCAL_ROOT
+# It is used for relative settings elsewhere.
+LOCAL_ROOT = os.path.abspath(os.path.dirname(__file__))
+
+WSGI_APPLICATION = "{}.wsgi.application".format(PROJECT_NAME)
+
+# Language code for this installation. All choices can be found here:
+# http://www.i18nguy.com/unicode/language-identifiers.html
+LANGUAGE_CODE = os.getenv('LANGUAGE_CODE', "en")
+
+if PROJECT_NAME not in INSTALLED_APPS:
+    INSTALLED_APPS += (PROJECT_NAME,)
+
+# Location of url mappings
+ROOT_URLCONF = os.getenv('ROOT_URLCONF', '{}.urls'.format(PROJECT_NAME))
+
+# Additional directories which hold static files
+STATICFILES_DIRS.append(
+    os.path.join(LOCAL_ROOT, "static"),
+)
+
+# Location of locale files
+LOCALE_PATHS = (
+    os.path.join(LOCAL_ROOT, 'locale'),
+    ) + LOCALE_PATHS
+
+TEMPLATES[0]['DIRS'].insert(0, os.path.join(LOCAL_ROOT, "templates"))
+loaders = TEMPLATES[0]['OPTIONS'].get('loaders') or ['django.template.loaders.filesystem.Loader','django.template.loaders.app_directories.Loader']
+# loaders.insert(0, 'apptemplates.Loader')
+TEMPLATES[0]['OPTIONS']['loaders'] = loaders
+TEMPLATES[0].pop('APP_DIRS', None)
+
+UNOCONV_ENABLE = strtobool(os.getenv('UNOCONV_ENABLE', 'True'))
+
+if UNOCONV_ENABLE:
+    UNOCONV_EXECUTABLE = os.getenv('UNOCONV_EXECUTABLE', '/usr/bin/unoconv')
+    UNOCONV_TIMEOUT = os.getenv('UNOCONV_TIMEOUT', 30)  # seconds

--- a/igb/static/README
+++ b/igb/static/README
@@ -1,0 +1,20 @@
+# Introduction
+
+This directory is used to store static assets for your project. User media files
+(FileFields/ImageFields) are not stored here.
+
+The convention for this directory is:
+
+ * css/ — stores CSS files
+ * less/ - stores LESS files
+ * js/ — stores Javascript files
+ * img/ — stores image files
+
+# Gulp
+
+Gulp can be used to automatically build css from LESS files.  The gulp process will
+watch you LESS files for changes and recompile.  To install gulp do
+the following 2 steps:
+
+1.  cd into the project directory and install dependencies with `npm install`
+2.  install gulp command line globally with `sudo npm install -g gulp`

--- a/igb/static/gulpfile.js
+++ b/igb/static/gulpfile.js
@@ -1,0 +1,23 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var pkg = require('./package.json');
+var concat = require('gulp-concat');
+var less = require('gulp-less');
+var del = require('del');
+
+gulp.task('clean:site_base.css', [], function () {
+  return del([ './css/site_base.css' ]);
+});
+
+gulp.task('compile:site_base.css', [], function() {
+  return gulp.src(["./less/site_base.less"], {base: './'})
+    .pipe(less({}))
+    .pipe(concat("site_base.css"))
+    .pipe(gulp.dest("./css"));
+});
+
+gulp.task('watch', function() {
+  gulp.watch("./less/**/*", ['clean:site_base.css', 'compile:site_base.css']);
+});
+
+gulp.task('default', ['watch', 'clean:site_base.css', 'compile:site_base.css']);

--- a/igb/static/package.json
+++ b/igb/static/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "igb",
+  "version": "0.0.1",
+  "author": "GeoNode Developers",
+  "description": "Static code and assets for igb",
+  "contributors": [
+    {
+    }
+  ],
+  "scripts": {
+    "test": "jshint **.js"
+  },
+  "license": "BSD",
+  "private": "false",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "del": "*",
+    "gulp": "^3.9.0",
+    "gulp-util": "*",
+    "gulp-concat": "*",
+    "gulp-less": "*",
+    "path": "*"
+  }
+}

--- a/igb/templates/geonode_base.html
+++ b/igb/templates/geonode_base.html
@@ -1,0 +1,4 @@
+{% extends "site_base.html" %}
+
+{% load i18n %}
+{% load staticfiles %}

--- a/igb/templates/site_base.html
+++ b/igb/templates/site_base.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block extra_head %}
+      <link href="{{ STATIC_URL }}css/site_base.css" rel="stylesheet"/>
+{% endblock %}
+{% block extra_tab %}
+{% comment %}
+Add Tab for Third Party Apps
+<li>
+ <a href="{{ PROJECT_ROOT }}app">App</a>
+</li>
+{% endcomment %}
+{% endblock %}

--- a/igb/templates/site_index.html
+++ b/igb/templates/site_index.html
@@ -1,0 +1,17 @@
+{% extends 'index.html' %}
+{% load i18n %}
+{% comment %}
+This is where you can override the hero area block. You can simply modify the content below or replace it wholesale to meet your own needs.
+{% endcomment %}
+{% block hero %}
+<div class="jumbotron">
+  <div class="container">
+      <h1>{{custom_theme.jumbotron_welcome_title|default:_("Welcome")}}</h1>
+      <p></p>
+      <p>{{custom_theme.jumbotron_welcome_content|default:_("GeoNode is an open source platform for sharing geospatial data and maps.")}}</p>
+      {% if not custom_theme.jumbotron_cta_hide %}
+      <p><a class="btn btn-default btn-lg" target="_blank" href="{{custom_theme.jumbotron_cta_link|default:_("http://docs.geonode.org/en/master/tutorials/users/index.html")}}" role="button">{{custom_theme.jumbotron_cta_text|default:_("Get Started &raquo;")}}</a></p>
+      {% endif %}
+  </div>
+</div>
+{% endblock hero %}

--- a/igb/templates/site_index.html
+++ b/igb/templates/site_index.html
@@ -6,9 +6,9 @@ This is where you can override the hero area block. You can simply modify the co
 {% block hero %}
 <div class="jumbotron">
   <div class="container">
-      <h1>{{custom_theme.jumbotron_welcome_title|default:_("Welcome")}}</h1>
+      <h1>{{custom_theme.jumbotron_welcome_title|default:_("IGB-GeoNode")}}</h1>
       <p></p>
-      <p>{{custom_theme.jumbotron_welcome_content|default:_("GeoNode is an open source platform for sharing geospatial data and maps.")}}</p>
+      <p>{{custom_theme.jumbotron_welcome_content|default:_("This is the custom GeoNode install for IGB")}}</p>
       {% if not custom_theme.jumbotron_cta_hide %}
       <p><a class="btn btn-default btn-lg" target="_blank" href="{{custom_theme.jumbotron_cta_link|default:_("http://docs.geonode.org/en/master/tutorials/users/index.html")}}" role="button">{{custom_theme.jumbotron_cta_text|default:_("Get Started &raquo;")}}</a></p>
       {% endif %}

--- a/igb/urls.py
+++ b/igb/urls.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+from django.conf.urls import url, include
+from django.views.generic import TemplateView
+
+from geonode.urls import urlpatterns
+
+urlpatterns += [
+## include your urls here
+
+]
+
+urlpatterns = [
+   url(r'^/?$',
+       TemplateView.as_view(template_name='site_index.html'),
+       name='home'),
+ ] + urlpatterns

--- a/igb/version.py
+++ b/igb/version.py
@@ -1,0 +1,52 @@
+import datetime
+import os
+import subprocess
+
+
+def get_version(version=None):
+    "Returns a PEP 386-compliant version number from VERSION."
+    if version is None:
+        from geonode import __version__ as version
+    else:
+        assert len(version) == 5
+        assert version[3] in ('unstable', 'beta', 'rc', 'final')
+
+    # Now build the two parts of the version number:
+    # main = X.Y[.Z]
+    # sub = .devN - for pre-alpha releases
+    #     | {a|b|c}N - for alpha, beta and rc releases
+
+    parts = 2 if version[2] == 0 else 3
+    main = '.'.join(str(x) for x in version[:parts])
+
+    sub = ''
+    if version[3] == 'unstable':
+        git_changeset = get_git_changeset()
+        if git_changeset:
+            sub = '.dev%s' % git_changeset
+
+    elif version[3] != 'final':
+        mapping = {'beta': 'b', 'rc': 'rc'}
+        sub = mapping[version[3]] + str(version[4])
+
+    return main + sub
+
+
+def get_git_changeset():
+    """Returns a numeric identifier of the latest git changeset.
+
+    The result is the UTC timestamp of the changeset in YYYYMMDDHHMMSS format.
+    This value isn't guaranteed to be unique, but collisions are very unlikely,
+    so it's sufficient for generating the development version numbers.
+    """
+    repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    git_show = subprocess.Popen('git show --pretty=format:%ct --quiet HEAD',
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                shell=True, cwd=repo_dir, universal_newlines=True)
+    timestamp = git_show.communicate()[0].partition('\n')[0]
+    try:
+        timestamp = datetime.datetime.utcfromtimestamp(int(timestamp))
+    except ValueError:
+        return None
+    return timestamp.strftime('%Y%m%d%H%M%S')
+

--- a/igb/wsgi.py
+++ b/igb/wsgi.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+"""
+WSGI config for igb project.
+
+This module contains the WSGI application used by Django's development server
+and any production WSGI deployments. It should expose a module-level variable
+named ``application``. Django's ``runserver`` and ``runfcgi`` commands discover
+this application via the ``WSGI_APPLICATION`` setting.
+
+Usually you will have the standard Django WSGI application here, but it also
+might make sense to replace the whole Django WSGI application with a custom one
+that later delegates to the Django one. For example, you could introduce WSGI
+middleware here, or combine a Django application with an application of another
+framework.
+
+"""
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "igb.settings")
+
+# This application object is used by any WSGI server configured to use this
+# file. This includes Django's development server, if the WSGI_APPLICATION
+# setting points here.
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()
+
+# Apply WSGI middleware here.
+# from helloworld.wsgi import HelloWorldApplication
+# application = HelloWorldApplication(application)

--- a/jetty-runner.xml
+++ b/jetty-runner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+ <!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+ <Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Set name="contextPath">/geoserver</Set>
+    <Set name="war"><SystemProperty name="jetty.home" default="../"/>geoserver</Set>
+    <Call name="setAttribute">
+      <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+      <Arg>WONTMATCH</Arg>
+    </Call>
+ </Configure>

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2017 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+import sys
+
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "igb.settings")
+    execute_from_command_line(sys.argv)

--- a/package/support/geonode.binary
+++ b/package/support/geonode.binary
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-geonode.local_settings}
+
+if [ -n "$WORKON_HOME" ]; then
+    DJANGO_ADMIN_CMD=$WORKON_HOME/bin/django-admin >/dev/null 2>/dev/null
+elif hash django-admin 2>/dev/null; then
+    DJANGO_ADMIN_CMD=django-admin
+fi
+
+if [ -n "$DJANGO_ADMIN_CMD" ]; then
+    DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE $DJANGO_ADMIN_CMD $@
+else
+    DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE django-admin.py $@
+fi

--- a/package/support/geonode.updateip
+++ b/package/support/geonode.updateip
@@ -1,0 +1,213 @@
+#!/bin/bash
+
+usage () {
+    bname="$(basename $0)"
+    ret="$1"
+
+    cat <<EOF
+USAGE:
+  $bname <-p|--public> <public_ip>
+      substitute SITEURL with <public_ip>, append it
+      to ALLOWED_HOSTS in local_settings.py
+      and geoserver printing config lists
+      This is mandatory and must be the pubic extenral address you use to access GeoNode
+  $bname <-l|--local> <local_ip>
+      same as above but taking into account
+      LOCAL vs PUBLIC ip addresses (or names)
+      This is optional and if not specified the default is 'localhost'
+  $bname <-s|--secure>
+      HTTPS instead of HTTP protocol
+  $bname <-h|--help>
+      this help
+EOF
+
+    exit $ret
+}
+
+if [[ $# -eq 0 ]] ; then
+    usage 0
+    exit 0
+fi
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+IS_HTTPS=0
+case $key in
+    -h|--help)
+        usage 0
+        ;;
+    -p|--public)
+        PUBLIC_IP="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    -l|--local)
+        LOCAL_IP="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    -s|--secure)
+        IS_HTTPS=1
+        shift # past argument
+        ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+
+if [ -z "$PUBLIC_IP" ]; then
+    echo "Public IP is mandatory!"
+    usage 1
+fi
+
+if [ -z "$LOCAL_IP" ]; then
+    # LOCAL_IP=$PUBLIC_IP
+    LOCAL_IP="localhost"
+fi
+
+NET_PROTOCOL="http"
+if [[ $IS_HTTPS != 0 ]]; then
+    NET_PROTOCOL="https"
+fi
+
+# Getting the full netloc
+NEW_EXT_IP="$NET_PROTOCOL://$PUBLIC_IP"
+NEW_INT_IP="$NET_PROTOCOL://$LOCAL_IP"
+
+# Removing slash at the end of variables
+NEW_EXT_IP=${NEW_EXT_IP%/}
+NEW_INT_IP=${NEW_INT_IP%/}
+
+echo "PUBLIC_IP" $NEW_EXT_IP
+echo "LOCAL_IP" $NEW_INT_IP
+
+GEONODE_ETC=${GEONODE_ETC:-/etc/geonode}
+GEOSERVER_DATA_DIR=${GEOSERVER_DATA_DIR:-/usr/share/geoserver/data}
+TOMCAT_SERVICE=${TOMCAT_SERVICE:-"invoke-rc.d tomcat8"}
+APACHE_SERVICE=${APACHE_SERVICE:-"invoke-rc.d apache2"}
+
+# Replace SITEURL in $GEONODE_ETC/local_settings.py
+echo "Replacing SITEURL value with '$NEW_EXT_IP' in $GEONODE_ETC/local_settings.py ... " | tr -d '\n'
+sed -i "s@\(SITEURL[ 	]*=[ 	]*\).*@\1\'$NEW_EXT_IP\/'@g" $GEONODE_ETC/local_settings.py
+echo "done."
+
+echo "Adding entry for '$PUBLIC_IP' in $GEOSERVER_DATA_DIR/printing/config.yaml ... " | tr -d '\n'
+printing_config=$GEOSERVER_DATA_DIR/printing/config.yaml
+
+if grep -q "$PUBLIC_IP" "$printing_config"
+then
+    echo "'$PUBLIC_IP' already found to the printing whitelist."
+else
+    sed -i "s#hosts:#hosts:\n  - !ipMatch\n    ip: $PUBLIC_IP#g" $printing_config
+    echo "done."
+fi
+
+# if ALLOWED_HOSTS already exists ...
+# if grep -q "^[ 	]*ALLOWED_HOSTS[ 	]*=" "$GEONODE_ETC/local_settings.py"
+# then
+#     if [ $IS_REPLACE -eq 1 ]
+#     then
+#         echo "Replacing ALLOWED_HOSTS in $GEONODE_ETC/local_settings.py ... " | tr -d '\n'
+#         sed -i "s/^\([ 	]*ALLOWED_HOSTS[ 	]*=\).*/\1 [ 'localhost', '$NEWIP', ]/g" "$GEONODE_ETC/local_settings.py"
+#         echo "done."
+#     else
+#         echo "Adding $NEWIP to ALLOWED_HOSTS in $GEONODE_ETC/local_settings.py ... " | tr -d '\n'
+#         items="$(grep "^[ 	]*ALLOWED_HOSTS[ 	]*=" "$GEONODE_ETC/local_settings.py" | \
+#                  sed 's/^[ 	]*ALLOWED_HOSTS[ 	]*=[ 	]*\[//g;s/\][ 	]*$//g')"
+#         already_found=0
+#         oldifs="$IFS"
+#         IFS=','
+#         for item in $items
+#         do
+#             item_cls="$(echo "$item" | sed "s/^[ 	]*['\"]//g;s/['\"][ 	]*$//g")"
+#             if [ "$item_cls" = "$NEWIP" ]
+#             then
+#                 already_found=1
+#                 break
+#             fi
+#         done
+#         IFS="$oldifs"
+#         if [ $already_found -eq 0 ]
+#         then
+#             if echo "$items" | grep -q ',[ 	]*$'
+#             then
+#                 items="${items}'$NEWIP', "
+#             else
+#                 items="${items}, '$NEWIP', "
+#             fi
+#             sed -i "s/^\([ 	]*ALLOWED_HOSTS[ 	]*=\).*/\1 [ $items ]/g" "$GEONODE_ETC/local_settings.py"
+#             echo "done."
+#         else
+#             echo "'$NEWIP' already found in ALLOWED_HOSTS list."
+#         fi
+#     fi
+# else
+#     echo "Adding ALLOWED_HOSTS with in $GEONODE_ETC/local_settings.py ... " | tr -d '\n'
+#     echo "ALLOWED_HOSTS=['localhost', '$NEWIP', ]" >> $GEONODE_ETC/local_settings.py
+#     echo "done."
+# fi
+
+
+# silence the warnings from executing geonode command or they will pollute the commands output
+if grep -q "^[ 	]*SILENCED_SYSTEM_CHECKS[ 	]*=" "$GEONODE_ETC/local_settings.py"
+then
+    true
+else
+    echo "SILENCED_SYSTEM_CHECKS = ['1_8.W001', 'fields.W340']" >> $GEONODE_ETC/local_settings.py
+fi
+
+geonode fixsitename
+
+echo "Setting up oauth"
+# Set oauth keys
+oauth_keys=$(geonode fixoauthuri 2>&1)
+client_id=`echo $oauth_keys | cut -d \, -f 1`
+client_secret=`echo $oauth_keys | cut -d \, -f 2`
+
+# Updating OAuth2 Service Config
+oauth_config="$GEOSERVER_DATA_DIR/security/filter/geonode-oauth2/config.xml"
+sed -i "s|<cliendId>.*</cliendId>|<cliendId>$client_id</cliendId>|g" $oauth_config
+sed -i "s|<clientSecret>.*</clientSecret>|<clientSecret>$client_secret</clientSecret>|g" $oauth_config
+sed -i "s|<accessTokenUri>.*</accessTokenUri>|<accessTokenUri>$NEW_INT_IP/o/token/</accessTokenUri>|g" $oauth_config
+sed -i "s|<userAuthorizationUri>.*</userAuthorizationUri>|<userAuthorizationUri>$NEW_EXT_IP/o/authorize/</userAuthorizationUri>|g" $oauth_config
+sed -i "s|<redirectUri>.*</redirectUri>|<redirectUri>$NEW_EXT_IP/geoserver/</redirectUri>|g" $oauth_config
+sed -i "s|<checkTokenEndpointUrl>.*</checkTokenEndpointUrl>|<checkTokenEndpointUrl>$NEW_INT_IP/api/o/v4/tokeninfo/</checkTokenEndpointUrl>|g" $oauth_config
+sed -i "s|<logoutUri>.*</logoutUri>|<logoutUri>$NEW_EXT_IP/account/logout/</logoutUri>|g" $oauth_config
+
+# Updating REST Role Service Config
+sed -i "s|<baseUrl>.*</baseUrl>|<baseUrl>$NEW_INT_IP</baseUrl>|g" "$GEOSERVER_DATA_DIR/security/role/geonode REST role service/config.xml"
+
+# Updating GeoServer Global Config
+global_config="$GEOSERVER_DATA_DIR/global.xml"
+sed -i "s|<proxyBaseUrl>.*</proxyBaseUrl>|<proxyBaseUrl>$NEW_EXT_IP/geoserver</proxyBaseUrl>|g" $global_config
+
+# Restart tomcat server
+$TOMCAT_SERVICE restart
+
+echo "Waiting Tomcat Service to Restart..."
+sleep 30s
+
+# Restart apache server
+$APACHE_SERVICE restart
+echo "Waiting Apache HTTPD Service to Restart..."
+sleep 5s
+
+# Run updatelayers
+geonode updatelayers
+geonode set_all_layers_alternate
+geonode set_all_layers_metadata
+
+# Run updatemaplayerip
+geonode updatemaplayerip

--- a/pavement.py
+++ b/pavement.py
@@ -1,0 +1,1176 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import django
+import fileinput
+import glob
+import os
+import re
+import shutil
+import subprocess
+import signal
+import sys
+import time
+import urllib
+import urllib2
+import zipfile
+from urlparse import urlparse
+
+import yaml
+from paver.easy import (BuildFailure, call_task, cmdopts, info, needs, options,
+                        path, sh, task)
+from setuptools.command import easy_install
+
+try:
+    from igb.local_settings import *
+except ImportError:
+    from igb.settings import *
+
+try:
+    from paver.path import pushd
+except ImportError:
+    from paver.easy import pushd
+
+from geonode.settings import (INSTALLED_APPS,
+                              GEONODE_CORE_APPS,
+                              GEONODE_INTERNAL_APPS,
+                              GEONODE_APPS,
+                              OGC_SERVER,
+                              ASYNC_SIGNALS)
+
+_django_11 = django.VERSION[0] == 1 and django.VERSION[1] >= 11 and django.VERSION[2] >= 2
+
+assert sys.version_info >= (2, 6), \
+    SystemError("GeoNode Build requires python 2.6 or better")
+
+dev_config = None
+with open("dev_config.yml", 'r') as f:
+    dev_config = yaml.load(f)
+
+
+def grab(src, dest, name):
+    download = True
+    if not dest.exists():
+        print('Downloading %s' % name)
+    elif not zipfile.is_zipfile(dest):
+        print('Downloading %s (corrupt file)' % name)
+    else:
+        download = False
+    if download:
+        if str(src).startswith("file://"):
+            src2 = src[7:]
+            if not os.path.exists(src2):
+                print("Source location (%s) does not exist" % str(src2))
+            else:
+                print("Copying local file from %s" % str(src2))
+                shutil.copyfile(str(src2), str(dest))
+        else:
+            # urllib.urlretrieve(str(src), str(dest))
+            from tqdm import tqdm
+            import requests
+            import math
+            # Streaming, so we can iterate over the response.
+            r = requests.get(str(src), stream=True, timeout=10, verify=False)
+            # Total size in bytes.
+            total_size = int(r.headers.get('content-length', 0))
+            print("Requesting %s" % str(src))
+            block_size = 1024
+            wrote = 0
+            with open('output.bin', 'wb') as f:
+                for data in tqdm(r.iter_content(block_size), total=math.ceil(total_size//block_size) , unit='KB', unit_scale=False):
+                    wrote = wrote  + len(data)
+                    f.write(data)
+            print(" total_size [%d] / wrote [%d] " % (total_size, wrote))
+            if total_size != 0 and wrote != total_size:
+                print("ERROR, something went wrong")
+            else:
+                shutil.move('output.bin', str(dest))
+            try:
+                # Cleaning up
+                os.remove('output.bin')
+            except OSError:
+                pass
+
+
+@task
+@cmdopts([
+    ('geoserver=', 'g', 'The location of the geoserver build (.war file).'),
+    ('jetty=', 'j', 'The location of the Jetty Runner (.jar file).'),
+])
+def setup_geoserver(options):
+    """Prepare a testing instance of GeoServer."""
+    # only start if using Geoserver backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.qgis_server' or 'geonode.geoserver' not in INSTALLED_APPS:
+        return
+
+    download_dir = path('downloaded')
+    if not download_dir.exists():
+        download_dir.makedirs()
+
+    geoserver_dir = path('geoserver')
+
+    geoserver_bin = download_dir / \
+        os.path.basename(dev_config['GEOSERVER_URL'])
+    jetty_runner = download_dir / \
+        os.path.basename(dev_config['JETTY_RUNNER_URL'])
+
+    grab(
+        options.get(
+            'geoserver',
+            dev_config['GEOSERVER_URL']),
+        geoserver_bin,
+        "geoserver binary")
+    grab(
+        options.get(
+            'jetty',
+            dev_config['JETTY_RUNNER_URL']),
+        jetty_runner,
+        "jetty runner")
+
+    if not geoserver_dir.exists():
+        geoserver_dir.makedirs()
+
+        webapp_dir = geoserver_dir / 'geoserver'
+        if not webapp_dir:
+            webapp_dir.makedirs()
+
+        print 'extracting geoserver'
+        z = zipfile.ZipFile(geoserver_bin, "r")
+        z.extractall(webapp_dir)
+
+    _install_data_dir()
+
+
+@task
+def setup_qgis_server(options):
+    """Prepare a testing instance of QGIS Server."""
+    # only start if using QGIS Server backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.geoserver' or 'geonode.qgis_server' not in INSTALLED_APPS:
+        return
+
+    # QGIS Server testing instance run on top of docker
+    try:
+        sh('scripts/misc/docker_check.sh')
+    except BaseException:
+        info("You need to have docker and docker-compose installed.")
+        return
+
+    info('Docker and docker-compose were installed.')
+    info('Proceeded to setup QGIS Server.')
+    info('Create QGIS Server related folder.')
+
+    try:
+        os.makedirs('geonode/qgis_layer')
+    except BaseException:
+        pass
+
+    try:
+        os.makedirs('geonode/qgis_tiles')
+    except BaseException:
+        pass
+
+    all_permission = 0o777
+    os.chmod('geonode/qgis_layer', all_permission)
+    stat = os.stat('geonode/qgis_layer')
+    info('Mode : %o' % stat.st_mode)
+    os.chmod('geonode/qgis_tiles', all_permission)
+    stat = os.stat('geonode/qgis_tiles')
+    info('Mode : %o' % stat.st_mode)
+
+    info('QGIS Server related folder successfully setup.')
+
+
+def _robust_rmtree(path, logger=None, max_retries=5):
+    """Try to delete paths robustly .
+    Retries several times (with increasing delays) if an OSError
+    occurs.  If the final attempt fails, the Exception is propagated
+    to the caller. Taken from https://github.com/hashdist/hashdist/pull/116
+    """
+
+    for i in range(max_retries):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as e:
+            if logger:
+                info('Unable to remove path: %s' % path)
+                info('Retrying after %d seconds' % i)
+            time.sleep(i)
+
+    # Final attempt, pass any Exceptions up to caller.
+    shutil.rmtree(path)
+
+
+def _install_data_dir():
+    target_data_dir = path('geoserver/data')
+    if target_data_dir.exists():
+        try:
+            target_data_dir.rmtree()
+        except OSError:
+            _robust_rmtree(target_data_dir, logger=True)
+
+    original_data_dir = path('geoserver/geoserver/data')
+    justcopy(original_data_dir, target_data_dir)
+
+    try:
+        config = path(
+            'geoserver/data/global.xml')
+        with open(config) as f:
+            xml = f.read()
+            m = re.search('proxyBaseUrl>([^<]+)', xml)
+            xml = xml[:m.start(1)] + \
+                "http://localhost:8080/geoserver" + xml[m.end(1):]
+            with open(config, 'w') as f:
+                f.write(xml)
+    except Exception as e:
+        print(e)
+
+    try:
+        config = path(
+            'geoserver/data/security/filter/geonode-oauth2/config.xml')
+        with open(config) as f:
+            xml = f.read()
+            m = re.search('accessTokenUri>([^<]+)', xml)
+            xml = xml[:m.start(1)] + \
+                "http://localhost:8000/o/token/" + xml[m.end(1):]
+            m = re.search('userAuthorizationUri>([^<]+)', xml)
+            xml = xml[:m.start(
+                1)] + "http://localhost:8000/o/authorize/" + xml[m.end(1):]
+            m = re.search('redirectUri>([^<]+)', xml)
+            xml = xml[:m.start(
+                1)] + "http://localhost:8080/geoserver/index.html" + xml[m.end(1):]
+            m = re.search('checkTokenEndpointUrl>([^<]+)', xml)
+            xml = xml[:m.start(
+                1)] + "http://localhost:8000/api/o/v4/tokeninfo/" + xml[m.end(1):]
+            m = re.search('logoutUri>([^<]+)', xml)
+            xml = xml[:m.start(
+                1)] + "http://localhost:8000/account/logout/" + xml[m.end(1):]
+            with open(config, 'w') as f:
+                f.write(xml)
+    except Exception as e:
+        print(e)
+
+    try:
+        config = path(
+            'geoserver/data/security/role/geonode REST role service/config.xml')
+        with open(config) as f:
+            xml = f.read()
+            m = re.search('baseUrl>([^<]+)', xml)
+            xml = xml[:m.start(1)] + "http://localhost:8000" + xml[m.end(1):]
+            with open(config, 'w') as f:
+                f.write(xml)
+    except Exception as e:
+        print(e)
+
+
+@task
+def static(options):
+    with pushd('geonode/static'):
+        sh('grunt production')
+
+
+@task
+@needs([
+    'setup_geoserver',
+    'setup_qgis_server',
+])
+def setup(options):
+    """Get dependencies and prepare a GeoNode development environment."""
+
+    updategeoip(options)
+    info(('GeoNode development environment successfully set up.'
+          'If you have not set up an administrative account,'
+          ' please do so now. Use "paver start" to start up the server.'))
+
+
+def grab_winfiles(url, dest, packagename):
+    # Add headers
+    headers = {'User-Agent': 'Mozilla 5.10'}
+    request = urllib2.Request(url, None, headers)
+    response = urllib2.urlopen(request)
+    with open(dest, 'wb') as writefile:
+        writefile.write(response.read())
+
+
+@task
+def win_install_deps(options):
+    """
+    Install all Windows Binary automatically
+    This can be removed as wheels become available for these packages
+    """
+    download_dir = path('downloaded').abspath()
+    if not download_dir.exists():
+        download_dir.makedirs()
+    win_packages = {
+        # required by transifex-client
+        "Py2exe": dev_config['WINDOWS']['py2exe'],
+        "Nose": dev_config['WINDOWS']['nose'],
+        # the wheel 1.9.4 installs but pycsw wants 1.9.3, which fails to compile
+        # when pycsw bumps their pyproj to 1.9.4 this can be removed.
+        "PyProj": dev_config['WINDOWS']['pyproj'],
+        "lXML": dev_config['WINDOWS']['lxml']
+    }
+    failed = False
+    for package, url in win_packages.iteritems():
+        tempfile = download_dir / os.path.basename(url)
+        print "Installing file ... " + tempfile
+        grab_winfiles(url, tempfile, package)
+        try:
+            easy_install.main([tempfile])
+        except Exception as e:
+            failed = True
+            print "install failed with error: ", e
+        os.remove(tempfile)
+    if failed and sys.maxsize > 2**32:
+        print "64bit architecture is not currently supported"
+        print "try finding the 64 binaries for py2exe, nose, and pyproj"
+    elif failed:
+        print "install failed for py2exe, nose, and/or pyproj"
+    else:
+        print "Windows dependencies now complete.  Run pip install -e geonode --use-mirrors"
+
+
+@cmdopts([
+    ('version=', 'v', 'Legacy GeoNode version of the existing database.')
+])
+@task
+def upgradedb(options):
+    """
+    Add 'fake' data migrations for existing tables from legacy GeoNode versions
+    """
+    version = options.get('version')
+    if version in ['1.1', '1.2']:
+        sh("python -W ignore manage.py migrate maps 0001 --fake")
+        sh("python -W ignore manage.py migrate avatar 0001 --fake")
+    elif version is None:
+        print "Please specify your GeoNode version"
+    else:
+        print "Upgrades from version %s are not yet supported." % version
+
+
+@task
+def updategeoip(options):
+    """
+    Update geoip db
+    """
+    settings = options.get('settings', '')
+    if settings:
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings
+
+    sh("%s python -W ignore manage.py updategeoip -o" % settings)
+
+
+@task
+@cmdopts([
+    ('settings', 's', 'Specify custom DJANGO_SETTINGS_MODULE')
+])
+def sync(options):
+    """
+    Run the migrate and migrate management commands to create and migrate a DB
+    """
+    settings = options.get('settings', '')
+    if settings:
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings
+
+    sh("%s python -W ignore manage.py makemigrations --noinput" % settings)
+    sh("%s python -W ignore manage.py migrate --noinput" % settings)
+    sh("%s python -W ignore manage.py loaddata fixtures/sample_admin.json" % settings)
+    sh("%s python -W ignore manage.py loaddata fixtures/default_oauth_apps.json" %
+       settings)
+    sh("%s python -W ignore manage.py loaddata fixtures/initial_data.json" % settings)
+    sh("%s python -W ignore manage.py set_all_layers_alternate" % settings)
+
+
+@task
+def package(options):
+    """
+    Creates a tarball to use for building the system elsewhere
+    """
+    import tarfile
+    import geonode
+
+    version = geonode.get_version()
+    # Use GeoNode's version for the package name.
+    pkgname = 'GeoNode-%s-all' % version
+
+    # Create the output directory.
+    out_pkg = path(pkgname)
+    out_pkg_tar = path("%s.tar.gz" % pkgname)
+
+    # Create a distribution in zip format for the geonode python package.
+    dist_dir = path('dist')
+    dist_dir.rmtree()
+    sh('python setup.py sdist --formats=zip')
+
+    with pushd('package'):
+
+        # Delete old tar files in that directory
+        for f in glob.glob('GeoNode*.tar.gz'):
+            old_package = path(f)
+            if old_package != out_pkg_tar:
+                old_package.remove()
+
+        if out_pkg_tar.exists():
+            info('There is already a package for version %s' % version)
+            return
+
+        # Clean anything that is in the oupout package tree.
+        out_pkg.rmtree()
+        out_pkg.makedirs()
+
+        support_folder = path('support')
+        install_file = path('install.sh')
+
+        # And copy the default files from the package folder.
+        justcopy(support_folder, out_pkg / 'support')
+        justcopy(install_file, out_pkg)
+
+        geonode_dist = path('..') / 'dist' / 'GeoNode-%s.zip' % version
+        justcopy(geonode_dist, out_pkg)
+
+        # Create a tar file with all files in the output package folder.
+        tar = tarfile.open(out_pkg_tar, "w:gz")
+        for file in out_pkg.walkfiles():
+            tar.add(file)
+
+        # Add the README with the license and important links to documentation.
+        tar.add('README', arcname=('%s/README.rst' % out_pkg))
+        tar.close()
+
+        # Remove all the files in the temporary output package directory.
+        out_pkg.rmtree()
+
+    # Report the info about the new package.
+    info("%s created" % out_pkg_tar.abspath())
+
+
+@task
+@needs(['start_geoserver',
+        'start_qgis_server',
+        'start_django'])
+@cmdopts([
+    ('bind=', 'b', 'Bind server to provided IP address and port number.'),
+    ('java_path=', 'j', 'Full path to java install for Windows'),
+    ('foreground', 'f', 'Do not run in background but in foreground'),
+    ('settings', 's', 'Specify custom DJANGO_SETTINGS_MODULE')
+], share_with=['start_django', 'start_geoserver'])
+def start():
+    """
+    Start GeoNode (Django, GeoServer & Client)
+    """
+    sh('sleep 30')
+    info("GeoNode is now available.")
+
+
+@task
+def stop_django():
+    """
+    Stop the GeoNode Django application
+    """
+    kill('python', 'celery')
+    kill('python', 'runserver')
+    kill('python', 'runmessaging')
+
+
+@task
+def stop_geoserver():
+    """
+    Stop GeoServer
+    """
+    # only start if using Geoserver backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.qgis_server' or 'geonode.geoserver' not in INSTALLED_APPS:
+        return
+    kill('java', 'geoserver')
+
+    # Kill process.
+    try:
+        # proc = subprocess.Popen("ps -ef | grep -i -e '[j]ava\|geoserver' |
+        # awk '{print $2}'",
+        proc = subprocess.Popen(
+            "ps -ef | grep -i -e 'geoserver' | awk '{print $2}'",
+                                shell=True,
+                                stdout=subprocess.PIPE)
+        for pid in proc.stdout:
+            info('Stopping geoserver (process number %s)' % int(pid))
+            os.kill(int(pid), signal.SIGKILL)
+            os.kill(int(pid), 9)
+            sh('sleep 30')
+            # Check if the process that we killed is alive.
+            try:
+                os.kill(int(pid), 0)
+                # raise Exception("""wasn't able to kill the process\nHINT:use
+                # signal.SIGKILL or signal.SIGABORT""")
+            except OSError as ex:
+                continue
+    except Exception as e:
+        info(e)
+
+
+@task
+@cmdopts([
+    ('qgis_server_port=', 'p', 'The port of the QGIS Server instance.')
+])
+def stop_qgis_server():
+    """
+    Stop QGIS Server Backend.
+    """
+    # only start if using QGIS Server backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.geoserver' or 'geonode.qgis_server' not in INSTALLED_APPS:
+        return
+    port = options.get('qgis_server_port', '9000')
+
+    sh(
+        'docker-compose -f docker-compose-qgis-server.yml down',
+        env={
+            'GEONODE_PROJECT_PATH': os.getcwd(),
+            'QGIS_SERVER_PORT': port
+        })
+
+
+@task
+@needs([
+    'stop_geoserver',
+    'stop_qgis_server'
+])
+def stop():
+    """
+    Stop GeoNode
+    """
+    # windows needs to stop the geoserver first b/c we can't tell which python
+    # is running, so we kill everything
+    info("Stopping GeoNode ...")
+    stop_django()
+
+
+@cmdopts([
+    ('bind=', 'b', 'Bind server to provided IP address and port number.')
+])
+@task
+def start_django():
+    """
+    Start the GeoNode Django application
+    """
+    settings = options.get('settings', '')
+    if settings:
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings
+    bind = options.get('bind', '0.0.0.0:8000')
+    foreground = '' if options.get('foreground', False) else '&'
+    sh('%s python -W ignore manage.py runserver %s %s' % (settings, bind, foreground))
+
+    celery_queues = [
+        "default",
+        "geonode",
+        "cleanup",
+        "update",
+        "email",
+        # Those queues are directly managed by messages.consumer
+        # "broadcast",
+        # "email.events",
+        # "all.geoserver",
+        # "geoserver.events",
+        # "geoserver.data",
+        # "geoserver.catalog",
+        # "notifications.events",
+        # "geonode.layer.viewer"
+    ]
+    sh('%s celery -A geonode.celery_app:app worker -Q %s -B -E -l INFO %s' % (settings, ",".join(celery_queues),foreground))
+
+    if ASYNC_SIGNALS:
+        sh('%s python -W ignore manage.py runmessaging %s' % (settings, foreground))
+
+
+def start_messaging():
+    """
+    Start the GeoNode messaging server
+    """
+    settings = options.get('settings', '')
+    if settings:
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings
+    foreground = '' if options.get('foreground', False) else '&'
+    sh('%s python -W ignore manage.py runmessaging %s' % (settings, foreground))
+
+
+@cmdopts([
+    ('java_path=', 'j', 'Full path to java install for Windows')
+])
+@task
+def start_geoserver(options):
+    """
+    Start GeoServer with GeoNode extensions
+    """
+    # only start if using Geoserver backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.qgis_server' or 'geonode.geoserver' not in INSTALLED_APPS:
+        return
+
+    GEOSERVER_BASE_URL = OGC_SERVER['default']['LOCATION']
+    url = GEOSERVER_BASE_URL
+
+    if urlparse(GEOSERVER_BASE_URL).hostname != 'localhost':
+        print "Warning: OGC_SERVER['default']['LOCATION'] hostname is not equal to 'localhost'"
+
+    if not GEOSERVER_BASE_URL.endswith('/'):
+        print "Error: OGC_SERVER['default']['LOCATION'] does not end with a '/'"
+        sys.exit(1)
+
+    download_dir = path('downloaded').abspath()
+    jetty_runner = download_dir / \
+        os.path.basename(dev_config['JETTY_RUNNER_URL'])
+    data_dir = path('geoserver/data').abspath()
+    geofence_dir = path('geoserver/data/geofence').abspath()
+    web_app = path('geoserver/geoserver').abspath()
+    log_file = path('geoserver/jetty.log').abspath()
+    config = path('scripts/misc/jetty-runner.xml').abspath()
+    jetty_port = urlparse(GEOSERVER_BASE_URL).port
+
+    import socket
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    socket_free = True
+    try:
+        s.bind(("127.0.0.1", jetty_port))
+    except socket.error as e:
+        socket_free = False
+        if e.errno == 98:
+            info('Port %s is already in use' % jetty_port)
+        else:
+            info(
+                'Something else raised the socket.error exception while checking port %s' %
+                jetty_port)
+            print(e)
+    finally:
+        s.close()
+
+    if socket_free:
+        # @todo - we should not have set workdir to the datadir but a bug in geoserver
+        # prevents geonode security from initializing correctly otherwise
+        with pushd(data_dir):
+            javapath = "java"
+            loggernullpath = os.devnull
+
+            # checking if our loggernullpath exists and if not, reset it to
+            # something manageable
+            if loggernullpath == "nul":
+                try:
+                    open("../../downloaded/null.txt", 'w+').close()
+                except IOError as e:
+                    print "Chances are that you have Geoserver currently running.  You \
+                            can either stop all servers with paver stop or start only \
+                            the django application with paver start_django."
+                    sys.exit(1)
+                loggernullpath = "../../downloaded/null.txt"
+
+            try:
+                sh(('java -version'))
+            except BaseException:
+                print "Java was not found in your path.  Trying some other options: "
+                javapath_opt = None
+                if os.environ.get('JAVA_HOME', None):
+                    print "Using the JAVA_HOME environment variable"
+                    javapath_opt = os.path.join(os.path.abspath(
+                        os.environ['JAVA_HOME']), "bin", "java.exe")
+                elif options.get('java_path'):
+                    javapath_opt = options.get('java_path')
+                else:
+                    print "Paver cannot find java in the Windows Environment.  \
+                    Please provide the --java_path flag with your full path to \
+                    java.exe e.g. --java_path=C:/path/to/java/bin/java.exe"
+                    sys.exit(1)
+                # if there are spaces
+                javapath = 'START /B "" "' + javapath_opt + '"'
+
+            sh((
+                '%(javapath)s -Xms512m -Xmx2048m -server -XX:+UseConcMarkSweepGC -XX:MaxPermSize=512m'
+                ' -DGEOSERVER_DATA_DIR=%(data_dir)s'
+                ' -Dgeofence.dir=%(geofence_dir)s'
+                # ' -Dgeofence-ovr=geofence-datasource-ovr.properties'
+                # workaround for JAI sealed jar issue and jetty classloader
+                # ' -Dorg.eclipse.jetty.server.webapp.parentLoaderPriority=true'
+                ' -jar %(jetty_runner)s'
+                ' --port %(jetty_port)i'
+                ' --log %(log_file)s'
+                ' %(config)s'
+                ' > %(loggernullpath)s &' % locals()
+            ))
+
+        info('Starting GeoServer on %s' % url)
+
+    # wait for GeoServer to start
+    started = waitfor(url)
+    info('The logs are available at %s' % log_file)
+
+    if not started:
+        # If applications did not start in time we will give the user a chance
+        # to inspect them and stop them manually.
+        info(('GeoServer never started properly or timed out.'
+              'It may still be running in the background.'))
+        sys.exit(1)
+
+
+@task
+@cmdopts([
+    ('qgis_server_port=', 'p', 'The port of the QGIS Server instance.')
+])
+def start_qgis_server():
+    """Start QGIS Server instance with GeoNode related plugins."""
+    # only start if using QGIS Serrver backend
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.geoserver' or 'geonode.qgis_server' not in INSTALLED_APPS:
+        return
+    info('Starting up QGIS Server...')
+
+    port = options.get('qgis_server_port', '9000')
+
+    sh(
+        'docker-compose -f docker-compose-qgis-server.yml up -d qgis-server',
+        env={
+            'GEONODE_PROJECT_PATH': os.getcwd(),
+            'QGIS_SERVER_PORT': port
+        })
+    info('QGIS Server is up.')
+
+
+@task
+def test(options):
+    """
+    Run GeoNode's Unit Test Suite
+    """
+    sh("%s manage.py test %s.tests --noinput" % (options.get('prefix'),
+                                                 '.tests '.join(GEONODE_APPS)))
+
+
+@task
+@cmdopts([
+    ('local=', 'l', 'Set to True if running bdd tests locally')
+])
+def test_bdd():
+    """
+    Run GeoNode's BDD Test Suite
+    """
+    local = str2bool(options.get('local', 'false'))
+    if local:
+        call_task('reset_hard')
+        call_task('setup')
+    else:
+        call_task('reset')
+    call_task('setup')
+    call_task('sync')
+    sh('sleep 30')
+    info("GeoNode is now available, running the bdd tests now.")
+
+    sh('py.test')
+
+    if local:
+        call_task('reset_hard')
+
+
+@task
+def test_javascript(options):
+    with pushd('geonode/static/geonode'):
+        sh('./run-tests.sh')
+
+
+@task
+@cmdopts([
+    ('name=', 'n', 'Run specific tests.'),
+    ('settings', 's', 'Specify custom DJANGO_SETTINGS_MODULE')
+])
+def test_integration(options):
+    """
+    Run GeoNode's Integration test suite against the external apps
+    """
+    _backend = os.environ.get('BACKEND', OGC_SERVER['default']['BACKEND'])
+    if _backend == 'geonode.geoserver' or 'geonode.qgis_server' not in INSTALLED_APPS:
+        call_task('stop_geoserver')
+        _reset()
+        # Start GeoServer
+        call_task('start_geoserver')
+    else:
+        call_task('stop_qgis_server')
+        _reset()
+        # Start QGis Server
+        call_task('start_qgis_server')
+
+    sh('sleep 30')
+
+    name = options.get('name', 'geonode.tests.integration')
+    settings = options.get('settings', '')
+    if not settings and name == 'geonode.upload.tests.integration':
+        if _django_11:
+            sh("cp geonode/upload/tests/test_settings.py geonode/")
+            settings = 'geonode.test_settings'
+        else:
+            settings = 'geonode.upload.tests.test_settings'
+
+    success = False
+    try:
+        if name == 'geonode.tests.csw':
+            call_task('sync', options={'settings': settings})
+            call_task('start', options={'settings': settings})
+            call_task('setup_data', options={'settings': settings})
+
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings if settings else ''
+
+        if name == 'geonode.upload.tests.integration':
+            sh("%s python -W ignore manage.py makemigrations --noinput" % settings)
+            sh("%s python -W ignore manage.py migrate --noinput" % settings)
+            sh("%s python -W ignore manage.py loaddata sample_admin.json" % settings)
+            sh("%s python -W ignore manage.py loaddata geonode/base/fixtures/default_oauth_apps.json" %
+               settings)
+            sh("%s python -W ignore manage.py loaddata geonode/base/fixtures/initial_data.json" %
+               settings)
+            call_task('start_geoserver')
+            bind = options.get('bind', '0.0.0.0:8000')
+            foreground = '' if options.get('foreground', False) else '&'
+            sh('%s python -W ignore manage.py runmessaging %s' % (settings, foreground))
+            sh('%s python -W ignore manage.py runserver %s %s' %
+               (settings, bind, foreground))
+            sh('sleep 30')
+            settings = 'REUSE_DB=1 %s' % settings
+
+        live_server_option = '--liveserver=localhost:8000'
+        if _django_11:
+            live_server_option = ''
+
+        info("GeoNode is now available, running the tests now.")
+        sh(('%s python -W ignore manage.py test %s'
+            ' %s --noinput %s' % (settings, name, _keepdb, live_server_option)))
+
+    except BuildFailure as e:
+        info('Tests failed! %s' % str(e))
+    else:
+        success = True
+    finally:
+        # don't use call task here - it won't run since it already has
+        stop()
+
+    call_task('stop_geoserver')
+    _reset()
+    if not success:
+        sys.exit(1)
+
+
+@task
+@needs(['start_geoserver',
+        'start_qgis_server'])
+@cmdopts([
+    ('coverage', 'c', 'use this flag to generate coverage during test runs'),
+    ('local=', 'l', 'Set to True if running bdd tests locally')
+])
+def run_tests(options):
+    """
+    Executes the entire test suite.
+    """
+    if options.get('coverage'):
+        prefix = 'coverage run --branch --source=geonode \
+            --omit="*/management/*,*/test*,*/wsgi*,*/middleware*,*/context_processors*,geonode/qgis_server/*,geonode/contrib/*,geonode/upload/*"'
+    else:
+        prefix = 'python'
+    local = options.get('local', 'false')  # travis uses default to false
+    sh('%s manage.py test geonode.tests.smoke' % prefix)
+    call_task('test', options={'prefix': prefix})
+    call_task('test_integration')
+    call_task('test_integration', options={'name': 'geonode.tests.csw'})
+
+    # only start if using Geoserver backend
+    if 'geonode.geoserver' in INSTALLED_APPS:
+        call_task('test_integration',
+                  options={'name': 'geonode.upload.tests.integration',
+                           'settings': 'geonode.upload.tests.test_settings'})
+
+    call_task('test_bdd', options={'local': local})
+    sh('flake8 geonode')
+
+
+@task
+@needs(['stop'])
+def reset():
+    """
+    Reset a development environment (Database, GeoServer & Catalogue)
+    """
+    _reset()
+
+
+def _reset():
+    from geonode import settings
+    sh("rm -rf {path}".format(
+        path=os.path.join(settings.PROJECT_ROOT, 'development.db')
+        )
+    )
+    sh("rm -rf igb/development.db")
+    sh("rm -rf igb/uploaded/*")
+    _install_data_dir()
+
+
+@needs(['reset'])
+def reset_hard():
+    """
+    Reset a development environment (Database, GeoServer & Catalogue)
+    """
+    sh("git clean -dxf")
+
+
+@task
+@cmdopts([
+    ('type=', 't', 'Import specific data type ("vector", "raster", "time")'),
+    ('settings', 's', 'Specify custom DJANGO_SETTINGS_MODULE')
+])
+def setup_data():
+    """
+    Import sample data (from gisdata package) into GeoNode
+    """
+    import gisdata
+
+    ctype = options.get('type', None)
+
+    data_dir = gisdata.GOOD_DATA
+
+    if ctype in ['vector', 'raster', 'time']:
+        data_dir = os.path.join(gisdata.GOOD_DATA, ctype)
+
+    settings = options.get('settings', '')
+    if settings:
+        settings = 'DJANGO_SETTINGS_MODULE=%s' % settings
+
+    sh("%s python -W ignore manage.py importlayers %s -v2" % (settings, data_dir))
+
+
+@needs(['package'])
+@cmdopts([
+    ('key=', 'k', 'The GPG key to sign the package'),
+    ('ppa=', 'p', 'PPA this package should be published to.'),
+])
+def deb(options):
+    """
+    Creates debian packages.
+
+    Example uses:
+        paver deb
+        paver deb -k 12345
+        paver deb -k 12345 -p geonode/testing
+    """
+    key = options.get('key', None)
+    ppa = options.get('ppa', None)
+
+    version, simple_version = versions()
+
+    info('Creating package for GeoNode version %s' % version)
+
+    # Get rid of any uncommitted changes to debian/changelog
+    info('Getting rid of any uncommitted changes in debian/changelog')
+    sh('git checkout package/debian/changelog')
+
+    # Workaround for git-dch bug
+    # http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=594580
+    sh('rm -rf %s/.git' % (os.path.realpath('package')))
+    sh('ln -s %s %s' % (os.path.realpath('.git'), os.path.realpath('package')))
+
+    with pushd('package'):
+
+        # Install requirements
+        # sh('sudo apt-get -y install debhelper devscripts git-buildpackage')
+
+        # sh(('git-dch --spawn-editor=snapshot --git-author --new-version=%s'
+        #     ' --id-length=6 --ignore-branch --release' % (simple_version)))
+        # In case you publish from Ubuntu Xenial (git-dch is removed from upstream)
+        #  use the following line instead:
+        # sh(('gbp dch --spawn-editor=snapshot --git-author --new-version=%s'
+        #    ' --id-length=6 --ignore-branch --release' % (simple_version)))
+        distribution = "bionic"
+        # sh(('gbp dch --distribution=%s --force-distribution --spawn-editor=snapshot --git-author --new-version=%s'
+        #    ' --id-length=6 --ignore-branch --release' % (distribution, simple_version)))
+
+        deb_changelog = path('debian') / 'changelog'
+        for idx, line in enumerate(fileinput.input([deb_changelog], inplace=True)):
+            if idx == 0:
+                print "geonode (%s) %s; urgency=high" % (simple_version, distribution),
+            else:
+                print line.replace("urgency=medium", "urgency=high"),
+
+        # Revert workaround for git-dhc bug
+        sh('rm -rf .git')
+
+        if key is None and ppa is None:
+            print("A local installable package")
+            sh('debuild -uc -us -A')
+        elif key is None and ppa is not None:
+            print("A sources package, signed by daemon")
+            sh('debuild -S')
+        elif key is not None and ppa is None:
+            print("A signed installable package")
+            sh('debuild -k%s -A' % key)
+        elif key is not None and ppa is not None:
+            print("A signed, source package")
+            sh('debuild -k%s -S' % key)
+
+    if ppa is not None:
+        sh('dput ppa:%s geonode_%s_source.changes' % (ppa, simple_version))
+
+
+@task
+def publish():
+    if 'GPG_KEY_GEONODE' in os.environ:
+        key = os.environ['GPG_KEY_GEONODE']
+    else:
+        print "You need to set the GPG_KEY_GEONODE environment variable"
+        return
+
+    if 'PPA_GEONODE' in os.environ:
+        ppa = os.environ['PPA_GEONODE']
+    else:
+        ppa = None
+
+    call_task('deb', options={
+        'key': key,
+        'ppa': ppa,
+        # 'ppa': 'geonode/testing',
+        # 'ppa': 'geonode/unstable',
+    })
+
+    version, simple_version = versions()
+    if ppa:
+        sh('git add package/debian/changelog')
+        sh('git commit -m "Updated changelog for version %s"' % version)
+        sh('git tag -f %s' % version)
+        sh('git push origin %s' % version)
+        sh('git tag -f debian/%s' % simple_version)
+        sh('git push origin debian/%s' % simple_version)
+        # sh('git push origin master')
+        sh('python setup.py sdist upload -r pypi')
+
+
+def versions():
+    import geonode
+    from geonode.version import get_git_changeset
+    raw_version = geonode.__version__
+    version = geonode.get_version()
+    timestamp = get_git_changeset()
+
+    major, minor, revision, stage, edition = raw_version
+
+    branch = 'dev'
+
+    if stage == 'final':
+        stage = 'thefinal'
+
+    if stage == 'unstable':
+        tail = '%s%s' % (branch, timestamp)
+    else:
+        tail = '%s%s' % (stage, edition)
+
+    simple_version = '%s.%s.%s+%s' % (major, minor, revision, tail)
+    return version, simple_version
+
+
+def kill(arg1, arg2):
+    """Stops a proces that contains arg1 and is filtered by arg2
+    """
+    from subprocess import Popen, PIPE
+
+    # Wait until ready
+    t0 = time.time()
+    # Wait no more than these many seconds
+    time_out = 30
+    running = True
+
+    while running and time.time() - t0 < time_out:
+        if os.name == 'nt':
+            p = Popen('tasklist | find "%s"' % arg1, shell=True,
+                      stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=False)
+        else:
+            p = Popen('ps aux | grep %s' % arg1, shell=True,
+                      stdin=PIPE, stdout=PIPE, stderr=PIPE, close_fds=True)
+
+        lines = p.stdout.readlines()
+
+        running = False
+        for line in lines:
+            # this kills all java.exe and python including self in windows
+            if ('%s' %
+                arg2 in line) or (os.name == 'nt' and '%s' %
+                                  arg1 in line):
+                running = True
+
+                # Get pid
+                fields = line.strip().split()
+
+                info('Stopping %s (process number %s)' % (arg1, fields[1]))
+                if os.name == 'nt':
+                    kill = 'taskkill /F /PID "%s"' % fields[1]
+                else:
+                    kill = 'kill -9 %s 2> /dev/null' % fields[1]
+                os.system(kill)
+
+        # Give it a little more time
+        time.sleep(1)
+    else:
+        pass
+
+    if running:
+        raise Exception('Could not stop %s: '
+                        'Running processes are\n%s'
+                        % (arg1, '\n'.join([l.strip() for l in lines])))
+
+
+def waitfor(url, timeout=300):
+    started = False
+    for a in xrange(timeout):
+        try:
+            resp = urllib.urlopen(url)
+        except IOError:
+            pass
+        else:
+            if resp.getcode() == 200:
+                started = True
+                break
+        time.sleep(1)
+    return started
+
+
+def _copytree(src, dst, symlinks=False, ignore=None):
+    if not os.path.exists(dst):
+        os.makedirs(dst)
+    for item in os.listdir(src):
+        s = os.path.join(src, item)
+        d = os.path.join(dst, item)
+        if os.path.isdir(s):
+            shutil.copytree(s, d, symlinks, ignore)
+        elif os.path.isfile(s):
+            shutil.copy2(s, d)
+
+
+def justcopy(origin, target):
+    if os.path.isdir(origin):
+        shutil.rmtree(target, ignore_errors=True)
+        _copytree(origin, target)
+    elif os.path.isfile(origin):
+        if not os.path.exists(target):
+            os.makedirs(target)
+        shutil.copy(origin, target)
+
+
+def str2bool(v):
+    if v and len(v) > 0:
+        return v.lower() in ("yes", "true", "t", "1")
+    else:
+        return False

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,46 @@
+- name: Provision a GeoNode into Production
+  hosts: production
+  remote_user: ubuntu
+  vars:
+    app_name: igb
+    github_user: geonode
+    server_name: 0.0.0.0
+    deploy_user: ubuntu
+    code_repository: https://github.com/-----/igb.git" # e.g., "https://github.com/GeoNode/igb.git"
+    branch_name: master
+    virtualenv_dir: "/home/ubuntu/.venvs"
+    site_url: "http://localhost:8000/" # The public url of the GeoNode instance
+    geoserver_url: "http://build.geonode.org/geoserver/latest/geoserver-2.14.x.war" # geoserver_url should match what is found in dev_config.yml
+    pg_max_connections: 100
+    pg_shared_buffers: 128MB
+    tomcat_xms: "1024M"
+    tomcat_xmx: "2048M"
+    nginx_client_max_body_size: "400M"
+    letsencrypt: False
+  gather_facts: False
+  pre_tasks:
+    - name: Install python for Ansible
+      become: yes
+      become_user: root
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+    - name: 'Reconfigue Locales'
+      become: yes
+      become_user: root
+      shell: ""
+      with_items:
+        - "export LANGUAGE=en_US.UTF-8"
+        - "export LANG=en_US.UTF-8"
+        - "export LC_ALL=en_US.UTF-8"
+        - "locale-gen --purge en_US.UTF-8"
+        - "echo 'LANG=en_US.UTF-8\nLANGUAGE=en_US:en\n' > /etc/default/locale"
+    - name: "Install cul, vim, and unzip"
+      become: yes
+      become_user: root
+      apt: name="" state=latest
+      with_items:
+        - curl
+        - vim
+        - unzip
+    - setup: # aka gather_facts
+  roles:
+     - { role: GeoNode.geonode }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# GeoNode
+-e git+https://github.com/GeoNode/geonode.git@master#egg=geonode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 # GeoNode
 -e git+https://github.com/GeoNode/geonode.git@master#egg=geonode
+
+django-environ
+pathlib2

--- a/scripts/misc/apache2/geonode.conf.sample
+++ b/scripts/misc/apache2/geonode.conf.sample
@@ -1,0 +1,108 @@
+WSGIDaemonProcess geonode python-path=/home/geo/geonode:/home/geo/Envs/geonode/lib/python2.7/site-packages user=www-data threads=15 processes=2
+
+<VirtualHost *:80>
+    ServerName http://localhost
+    ServerAdmin webmaster@localhost
+    DocumentRoot /home/geo/geonode/geonode
+
+    LimitRequestFieldSize 32760
+    LimitRequestLine 32760
+
+    ErrorLog /var/log/apache2/error.log
+    LogLevel info
+    CustomLog /var/log/apache2/access.log combined
+
+    WSGIProcessGroup geonode
+    WSGIPassAuthorization On
+    WSGIScriptAlias / /home/geo/geonode/geonode/wsgi.py
+
+    Alias /static/ /home/geo/geonode/geonode/static_root/
+    Alias /uploaded/ /home/geo/geonode/geonode/uploaded/
+
+    <Directory "/home/geo/geonode/geonode/">
+         <Files wsgi.py>
+             Order deny,allow
+             Allow from all
+             Require all granted
+         </Files>
+
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/static_root/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/thumbs/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/avatars/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/people_group/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/group/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/documents/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/layers/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Directory "/home/geo/geonode/geonode/uploaded/img/">
+        Order allow,deny
+        Options Indexes FollowSymLinks
+        Allow from all
+        Require all granted
+        IndexOptions FancyIndexing
+    </Directory>
+
+    <Proxy *>
+        Order allow,deny
+        Allow from all
+    </Proxy>
+
+    ProxyPreserveHost On
+    ProxyPass /geoserver http://localhost:8080/geoserver
+    ProxyPassReverse /geoserver http://localhost:8080/geoserver
+
+</VirtualHost>

--- a/scripts/misc/cleanup_pyc.sh
+++ b/scripts/misc/cleanup_pyc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash 
+
+# This is the script directory
+# pushd $(dirname $0)
+
+# This is the current directory
+pushd $PWD
+
+find . -name "*.pyc" -exec rm -f {} \;

--- a/scripts/misc/jetty-runner.xml
+++ b/scripts/misc/jetty-runner.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"  encoding="ISO-8859-1"?>
+
+ <Configure class="org.eclipse.jetty.webapp.WebAppContext">
+     <Set name="contextPath">/geoserver</Set>
+     <Set name="war"><SystemProperty name="jetty.home" default="../geoserver"/></Set>
+     <Set name="descriptor">/WEB-INF/web.xml</Set>
+     <Set name="parentLoaderPriority">false</Set>
+     <Call name="setAttribute">
+       <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
+       <Arg>WONTMATCH</Arg>
+     </Call>
+  </Configure>

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#########################################################################
+#
+# Copyright (C) 2018 OSGeo
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#########################################################################
+
+import os
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    from pip.download import PipSession
+from distutils.core import setup
+
+from setuptools import find_packages
+
+# Parse requirements.txt to get the list of dependencies
+inst_req = parse_requirements('requirements.txt',
+                              session=PipSession())
+REQUIREMENTS = [str(r.req) for r in inst_req]
+
+def read(*rnames):
+    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+
+setup(
+    name="igb",
+    version="2.10.0",
+    author="",
+    author_email="",
+    description="igb, based on GeoNode",
+    long_description=(read('README.rst')),
+    # Full list of classifiers can be found at:
+    # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Development Status :: 1 - Planning',
+    ],
+    license="BSD",
+    keywords="igb geonode django",
+    url='https://github.com/igb/igb',
+    packages=['igb',],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=REQUIREMENTS,
+)

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,197 @@
+import ast
+import json
+import logging
+import os
+import re
+
+
+from invoke import run, task
+
+BOOTSTRAP_IMAGE_CHEIP = 'codenvy/che-ip:nightly'
+
+
+@task
+def waitfordbs(ctx):
+    print "**************************databases*******************************"
+    ctx.run("/usr/bin/wait-for-databases {0}".format('db'), pty=True)
+
+
+@task
+def update(ctx):
+    print "***************************initial*********************************"
+    ctx.run("env", pty=True)
+    pub_ip = _geonode_public_host_ip()
+    print "Public Hostname or IP is {0}".format(pub_ip)
+    pub_port = _geonode_public_port()
+    print "Public PORT is {0}".format(pub_port)
+    db_url = _update_db_connstring()
+    geodb_url = _update_geodb_connstring()
+    override_env = "$HOME/.override_env"
+    envs = {
+        "public_fqdn": "{0}:{1}".format(pub_ip, pub_port or 80),
+        "public_host": "{0}".format(pub_ip),
+        "dburl": db_url,
+        "geodburl": geodb_url,
+        "override_fn": override_env
+    }
+    if not os.environ.get('GEOSERVER_PUBLIC_LOCATION'):
+        ctx.run("echo export GEOSERVER_PUBLIC_LOCATION=\
+http://{public_fqdn}/gs/ >> {override_fn}".format(**envs), pty=True)
+    if not os.environ.get('SITEURL'):
+        ctx.run("echo export SITEURL=\
+http://{public_fqdn}/ >> {override_fn}".format(**envs), pty=True)
+
+    try:
+        current_allowed = ast.literal_eval(os.getenv('ALLOWED_HOSTS') or \
+                                           "['{public_fqdn}', '{public_host}', 'localhost', 'django', 'igb',]".format(**envs))
+    except ValueError:
+        current_allowed = []
+    current_allowed.extend(['{}'.format(pub_ip), '{}:{}'.format(pub_ip, pub_port)])
+    allowed_hosts = ['"{}"'.format(c) for c in current_allowed] + ['"geonode"', '"django"']
+
+    ctx.run('echo export ALLOWED_HOSTS="\\"{}\\"" >> {}'.format(allowed_hosts, override_env), pty=True)
+
+    if not os.environ.get('DATABASE_URL'):
+        ctx.run("echo export DATABASE_URL=\
+{dburl} >> {override_fn}".format(**envs), pty=True)
+    if not os.environ.get('GEODATABASE_URL'):
+        ctx.run("echo export GEODATABASE_URL=\
+{geodburl} >> {override_fn}".format(**envs), pty=True)
+    if not os.environ.get('ASYNC_SIGNALS'):
+        ctx.run("echo export ASYNC_SIGNALS=\
+True >> {override_fn}".format(**envs), pty=True)
+    if not os.environ.get('BROKER_URL'):
+        ctx.run("echo export BROKER_URL=\
+amqp://guest:guest@rabbitmq:5672/ >> {override_fn}".format(**envs), pty=True)
+    ctx.run("source $HOME/.override_env", pty=True)
+    print "****************************final**********************************"
+    ctx.run("env", pty=True)
+
+
+@task
+def migrations(ctx):
+    print "**************************migrations*******************************"
+    ctx.run("python manage.py makemigrations --noinput --merge --settings={0}".format(
+        _localsettings()
+    ), pty=True)
+    ctx.run("python manage.py makemigrations --noinput --settings={0}".format(
+        _localsettings()
+    ), pty=True)
+    ctx.run("python manage.py migrate --noinput --settings={0}".format(
+        _localsettings()
+    ), pty=True)
+    ctx.run("python manage.py updategeoip --settings={0}".format(
+        _localsettings()
+    ), pty=True)
+    try:
+        ctx.run("python manage.py rebuild_index --noinput --settings={0}".format(
+            _localsettings()
+        ), pty=True)
+    except:
+        pass
+
+@task
+def statics(ctx):
+    print "**************************migrations*******************************"
+    ctx.run('mkdir -p /mnt/volumes/statics/{static,uploads}')
+    ctx.run("python manage.py collectstatic --noinput --clear --settings={0}".format(
+        _localsettings()
+    ), pty=True)
+
+@task
+def prepare(ctx):
+    print "**********************prepare fixture***************************"
+    ctx.run("rm -rf /tmp/default_oauth_apps_docker.json", pty=True)
+    _prepare_oauth_fixture()
+
+
+@task
+def fixtures(ctx):
+    print "**************************fixtures********************************"
+    ctx.run("python manage.py loaddata sample_admin \
+--settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata /tmp/default_oauth_apps_docker.json \
+--settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py loaddata /usr/src/geonode/geonode/base/fixtures/initial_data.json \
+--settings={0}".format(_localsettings()), pty=True)
+    ctx.run("python manage.py set_all_layers_alternate \
+--settings={0}".format(_localsettings()), pty=True)
+
+
+@task
+def initialized(ctx):
+    print "**************************init file********************************"
+    ctx.run('date > /mnt/volumes/statics/geonode_init.lock')
+
+
+def _update_db_connstring():
+    user = os.getenv('GEONODE_DATABASE', 'geonode')
+    pwd = os.getenv('GEONODE_DATABASE_PASSWORD', 'geonode')
+    dbname = os.getenv('GEONODE_DATABASE', 'geonode')
+    connstr = 'postgres://{0}:{1}@db:5432/{2}'.format(
+        user,
+        pwd,
+        dbname
+    )
+    return connstr
+
+
+def _update_geodb_connstring():
+    geouser = os.getenv('GEONODE_GEODATABASE', 'geonode_data')
+    geopwd = os.getenv('GEONODE_GEODATABASE_PASSWORD', 'geonode_data')
+    geodbname = os.getenv('GEONODE_GEODATABASE', 'geonode_data')
+    geoconnstr = 'postgis://{0}:{1}@db:5432/{2}'.format(
+        geouser,
+        geopwd,
+        geodbname
+    )
+    return geoconnstr
+
+
+def _localsettings():
+    settings = os.getenv('DJANGO_SETTINGS_MODULE', 'igb.settings')
+    return settings
+
+
+def _geonode_public_host_ip():
+    gn_pub_hostip = os.getenv('GEONODE_LB_HOST_IP', 'localhost')
+    return gn_pub_hostip
+
+
+def _geonode_public_port():
+    gn_pub_port = os.getenv('GEONODE_LB_PORT', '80')
+    return gn_pub_port
+
+
+def _prepare_oauth_fixture():
+    pub_ip = _geonode_public_host_ip()
+    print "Public Hostname or IP is {0}".format(pub_ip)
+    pub_port = _geonode_public_port()
+    print "Public PORT is {0}".format(pub_port)
+    default_fixture = [
+        {
+            "model": "oauth2_provider.application",
+            "pk": 1001,
+            "fields": {
+                "skip_authorization": True,
+                "created": "2018-05-31T10:00:31.661Z",
+                "updated": "2018-05-31T11:30:31.245Z",
+                "algorithm": "RS256",
+                "redirect_uris": "http://{0}:{1}/geoserver/index.html".format(
+                    pub_ip, pub_port
+                ),
+                "name": "GeoServer",
+                "authorization_grant_type": "authorization-code",
+                "client_type": "confidential",
+                "client_id": "Jrchz2oPY3akmzndmgUTYrs9gczlgoV20YPSvqaV",
+                "client_secret": "\
+rCnp5txobUo83EpQEblM8fVj3QT5zb5qRfxNsuPzCqZaiRyIoxM4jdgMiZKFfePBHYXCLd7B8NlkfDB\
+Y9HKeIQPcy5Cp08KQNpRHQbjpLItDHv12GvkSeXp6OxaUETv3",
+                "user": [
+                    "admin"
+                ]
+            }
+        }
+    ]
+    with open('/tmp/default_oauth_apps_docker.json', 'w') as fixturefile:
+        json.dump(default_fixture, fixturefile)

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,15 @@
+[uwsgi]
+socket = 0.0.0.0:8000
+# http-socket = 0.0.0.0:8000
+chdir = /usr/src/igb/
+logto = /var/log/geonode.log
+pidfile = /tmp/geonode.pid
+harakiri = 300
+harakiri-verbose = true
+module = igb.wsgi:application
+master = 1
+processes = 4
+# plugins = python
+threads = 2
+home = /usr/local/
+# cron = -1 -1 -1 -1 -1 /usr/local/bin/python /usr/src/igb/manage.py collect_metrics -n

--- a/wait-for-databases.sh
+++ b/wait-for-databases.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+host="$1"
+shift
+
+until psql -h "$host" -U "postgres" -P "pager=off" -c '\l'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+until PGPASSWORD=${GEONODE_DATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_DATABASE} -d ${GEONODE_DATABASE} -P "pager=off" -c '\l'; do
+  >&2 echo "${GEONODE_DATABASE} is unavailable - sleeping"
+  sleep 1
+done
+
+until PGPASSWORD=${GEONODE_GEODATABASE_PASSWORD} psql -h "$host" -U ${GEONODE_GEODATABASE} -d ${GEONODE_GEODATABASE} -P "pager=off" -c '\l'; do
+  >&2 echo "${GEONODE_GEODATABASE} is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "GeoNode databases are up - executing command"


### PR DESCRIPTION
This PR adds an initial skeleton for the IGB-GeoNode project based on [geonode-project](https://github.com/GeoNode/geonode-project)

The PR does not explicitly squash its 2 commits since the first one is pretty much just the clean slate - clone the vanilla geonode-project.

The second commit brings in `django-environ` as a requirement in order to facilitate deployment based on the presence of environment variables. It currently results in the need to have the following environment variables previously defined in order to run this project

```
# this should be a comma-separated list of hosts
DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
DJANGO_SITEURL=http://localhost:8000/
DJANGO_DATABASE_URL=engine://user:password@host/dbname
DJANGO_SETTINGS_MODULE=igb.settings
DJANGO_SECRET_KEY=somesecret
DEBUG=True
GEONODE_DB_URL=engine://user:password@host/db_name
```

With this type of setup the main `settings.py` file should hold project specific configuration only, and thus does not need to be modified, all site-specific configs are loaded from the environment